### PR TITLE
refactor!: use quic-rpc 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,7 +1753,7 @@ dependencies = [
  "iroh-test",
  "nested_enum_utils",
  "postcard",
- "quic-rpc",
+ "quic-rpc 0.13.0 (git+https://github.com/n0-computer/quic-rpc?branch=map-transports-not-services)",
  "quic-rpc-derive",
  "rand",
  "rand_chacha",
@@ -2910,13 +2919,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "quic-rpc"
+version = "0.13.0"
+source = "git+https://github.com/n0-computer/quic-rpc?branch=map-transports-not-services#c30ba6a08c3ec0e1a05ff6f15a1681cd75ddcf0f"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "derive_more",
+ "educe",
+ "flume",
+ "futures-lite 2.3.0",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "iroh-quinn",
+ "pin-project",
+ "serde",
+ "slab",
+ "tokio",
+ "tokio-serde",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "quic-rpc-derive"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b91a3f7a42657cbfbd0c2499c1f037738eff45bb7f59c6ce3d3d9e890d141c"
 dependencies = [
  "proc-macro2",
- "quic-rpc",
+ "quic-rpc 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote",
  "syn 1.0.109",
 ]
@@ -4047,6 +4080,21 @@ dependencies = [
  "url",
  "webpki-roots",
  "x509-parser",
+]
+
+[[package]]
+name = "tokio-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
+dependencies = [
+ "bincode",
+ "bytes",
+ "educe",
+ "futures-core",
+ "futures-sink",
+ "pin-project",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,9 +226,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.5.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -259,7 +259,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.34"
+version = "1.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
+checksum = "0f57c4b4da2a9d619dd035f27316d7a426305b75be93d09e92f2b9229c34feaf"
 dependencies = [
  "shlex",
 ]
@@ -1333,6 +1333,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
@@ -1493,6 +1512,17 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -1510,7 +1540,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1528,6 +1558,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
@@ -1535,9 +1589,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
+ "h2 0.4.6",
  "http 1.1.0",
- "http-body",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1555,7 +1609,7 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper",
+ "hyper 1.5.0",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -1575,8 +1629,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body",
- "hyper",
+ "http-body 1.0.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1768,7 +1822,7 @@ dependencies = [
  "futures",
  "http 1.1.0",
  "http-body-util",
- "hyper",
+ "hyper 1.5.0",
  "hyper-util",
  "log",
  "rand",
@@ -1885,7 +1939,7 @@ dependencies = [
  "iroh-test",
  "nested_enum_utils",
  "postcard",
- "quic-rpc 0.14.0 (git+https://github.com/n0-computer/quic-rpc?branch=map-transports-not-services)",
+ "quic-rpc 0.14.0 (git+https://github.com/n0-computer/quic-rpc?branch=naming-bikeshedding)",
  "quic-rpc-derive",
  "rand",
  "rand_chacha",
@@ -1909,7 +1963,7 @@ dependencies = [
  "anyhow",
  "erased_set",
  "http-body-util",
- "hyper",
+ "hyper 1.5.0",
  "hyper-util",
  "once_cell",
  "prometheus-client",
@@ -1924,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "iroh-net"
 version = "0.28.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#258eb33ed598c25be98986463fc1f798b374848a"
+source = "git+https://github.com/n0-computer/iroh?branch=main#0a7a534128bf1234a326fcfba134d878e796c377"
 dependencies = [
  "anyhow",
  "axum",
@@ -1948,7 +2002,7 @@ dependencies = [
  "hostname",
  "http 1.1.0",
  "http-body-util",
- "hyper",
+ "hyper 1.5.0",
  "hyper-util",
  "igd-next",
  "iroh-base",
@@ -2058,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "iroh-router"
 version = "0.28.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#258eb33ed598c25be98986463fc1f798b374848a"
+source = "git+https://github.com/n0-computer/iroh?branch=main#0a7a534128bf1234a326fcfba134d878e796c377"
 dependencies = [
  "anyhow",
  "futures-buffered",
@@ -2404,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#258eb33ed598c25be98986463fc1f798b374848a"
+source = "git+https://github.com/n0-computer/iroh?branch=main#0a7a534128bf1234a326fcfba134d878e796c377"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2898,7 +2952,7 @@ checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 [[package]]
 name = "portmapper"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#258eb33ed598c25be98986463fc1f798b374848a"
+source = "git+https://github.com/n0-computer/iroh?branch=main#0a7a534128bf1234a326fcfba134d878e796c377"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3117,10 +3171,11 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.14.0"
-source = "git+https://github.com/n0-computer/quic-rpc?branch=map-transports-not-services#7bad06c7243b53b7c612e95293c1fb2d5643f864"
+source = "git+https://github.com/n0-computer/quic-rpc?branch=naming-bikeshedding#d9637d1982e90c1ee6fb65a62f354fb319ebfb37"
 dependencies = [
  "anyhow",
  "bincode",
+ "bytes",
  "derive_more",
  "educe",
  "flume",
@@ -3128,6 +3183,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
+ "hyper 0.14.31",
  "iroh-quinn",
  "pin-project",
  "serde",
@@ -3193,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e346e016eacfff12233c243718197ca12f148c84e1e84268a896699b41c71780"
+checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3345,9 +3401,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.1.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.5.0",
  "hyper-rustls",
  "hyper-util",
  "ipnet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,7 +3087,8 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.15.0"
-source = "git+https://github.com/n0-computer/quic-rpc?branch=map-transports-not-services#16b7c4942365b96fc750627459261e52e1190f6c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e131f594054d27d077162815db3b5e9ddd76a28fbb9091b68095971e75c286"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3107,7 +3108,8 @@ dependencies = [
 [[package]]
 name = "quic-rpc-derive"
 version = "0.15.0"
-source = "git+https://github.com/n0-computer/quic-rpc?branch=map-transports-not-services#16b7c4942365b96fc750627459261e52e1190f6c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbef4c942978f74ef296ae40d43d4375c9d730b65a582688a358108cfd5c0cf7"
 dependencies = [
  "proc-macro2",
  "quic-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,7 +1885,7 @@ dependencies = [
  "iroh-test",
  "nested_enum_utils",
  "postcard",
- "quic-rpc 0.13.0",
+ "quic-rpc 0.14.0 (git+https://github.com/n0-computer/quic-rpc?branch=map-transports-not-services)",
  "quic-rpc-derive",
  "rand",
  "rand_chacha",
@@ -1924,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "iroh-net"
 version = "0.28.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#134a93b5a60103b3ce8fa4aacb52cdbcb291d00b"
+source = "git+https://github.com/n0-computer/iroh?branch=main#258eb33ed598c25be98986463fc1f798b374848a"
 dependencies = [
  "anyhow",
  "axum",
@@ -1953,8 +1953,8 @@ dependencies = [
  "igd-next",
  "iroh-base",
  "iroh-metrics",
- "iroh-quinn 0.12.0",
- "iroh-quinn-proto 0.12.0",
+ "iroh-quinn",
+ "iroh-quinn-proto",
  "iroh-quinn-udp",
  "libc",
  "netdev",
@@ -2008,30 +2008,12 @@ dependencies = [
 
 [[package]]
 name = "iroh-quinn"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd590a39a14cfc168efa4d894de5039d65641e62d8da4a80733018ababe3c33"
-dependencies = [
- "bytes",
- "iroh-quinn-proto 0.11.6",
- "iroh-quinn-udp",
- "pin-project-lite",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "iroh-quinn"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35ba75a5c57cff299d2d7ca1ddee053f66339d1756bd79ec637bcad5aa61100e"
 dependencies = [
  "bytes",
- "iroh-quinn-proto 0.12.0",
+ "iroh-quinn-proto",
  "iroh-quinn-udp",
  "pin-project-lite",
  "rustc-hash",
@@ -2039,24 +2021,6 @@ dependencies = [
  "socket2",
  "thiserror",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "iroh-quinn-proto"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd0538ff12efe3d61ea1deda2d7913f4270873a519d43e6995c6e87a1558538"
-dependencies = [
- "bytes",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-platform-verifier",
- "slab",
- "thiserror",
- "tinyvec",
  "tracing",
 ]
 
@@ -2094,7 +2058,7 @@ dependencies = [
 [[package]]
 name = "iroh-router"
 version = "0.28.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#134a93b5a60103b3ce8fa4aacb52cdbcb291d00b"
+source = "git+https://github.com/n0-computer/iroh?branch=main#258eb33ed598c25be98986463fc1f798b374848a"
 dependencies = [
  "anyhow",
  "futures-buffered",
@@ -2440,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#134a93b5a60103b3ce8fa4aacb52cdbcb291d00b"
+source = "git+https://github.com/n0-computer/iroh?branch=main#258eb33ed598c25be98986463fc1f798b374848a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2934,7 +2898,7 @@ checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 [[package]]
 name = "portmapper"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#134a93b5a60103b3ce8fa4aacb52cdbcb291d00b"
+source = "git+https://github.com/n0-computer/iroh?branch=main#258eb33ed598c25be98986463fc1f798b374848a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3131,30 +3095,6 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.13.0"
-source = "git+https://github.com/n0-computer/quic-rpc?branch=map-transports-not-services#c30ba6a08c3ec0e1a05ff6f15a1681cd75ddcf0f"
-dependencies = [
- "anyhow",
- "bincode",
- "derive_more",
- "educe",
- "flume",
- "futures-lite 2.4.0",
- "futures-sink",
- "futures-util",
- "hex",
- "iroh-quinn 0.11.3",
- "pin-project",
- "serde",
- "slab",
- "tokio",
- "tokio-serde",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "quic-rpc"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8431b2e7c22929347b61a354d4936d71fe7ab1e6b0475dc50e98276970dfec"
@@ -3175,13 +3115,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "quic-rpc"
+version = "0.14.0"
+source = "git+https://github.com/n0-computer/quic-rpc?branch=map-transports-not-services#7bad06c7243b53b7c612e95293c1fb2d5643f864"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "derive_more",
+ "educe",
+ "flume",
+ "futures-lite 2.4.0",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "iroh-quinn",
+ "pin-project",
+ "serde",
+ "slab",
+ "tokio",
+ "tokio-serde",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "quic-rpc-derive"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403bc8506c847468e00170dbbbfe2c54d13b090031bcbe474cd3faea021cbd9f"
 dependencies = [
  "proc-macro2",
- "quic-rpc 0.14.0",
+ "quic-rpc 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote",
  "syn 1.0.109",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,9 +226,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -259,7 +259,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -319,15 +319,6 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -1333,25 +1324,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
@@ -1512,17 +1484,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -1540,7 +1501,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1558,30 +1519,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
@@ -1589,9 +1526,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.6",
+ "h2",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1609,7 +1546,7 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.5.0",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -1629,8 +1566,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.5.0",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1822,7 +1759,7 @@ dependencies = [
  "futures",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "hyper-util",
  "log",
  "rand",
@@ -1939,7 +1876,7 @@ dependencies = [
  "iroh-test",
  "nested_enum_utils",
  "postcard",
- "quic-rpc 0.14.0 (git+https://github.com/n0-computer/quic-rpc?branch=naming-bikeshedding)",
+ "quic-rpc",
  "quic-rpc-derive",
  "rand",
  "rand_chacha",
@@ -1963,7 +1900,7 @@ dependencies = [
  "anyhow",
  "erased_set",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "hyper-util",
  "once_cell",
  "prometheus-client",
@@ -2002,7 +1939,7 @@ dependencies = [
  "hostname",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "hyper-util",
  "igd-next",
  "iroh-base",
@@ -3149,9 +3086,8 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8431b2e7c22929347b61a354d4936d71fe7ab1e6b0475dc50e98276970dfec"
+version = "0.15.0"
+source = "git+https://github.com/n0-computer/quic-rpc?branch=map-transports-not-services#16b7c4942365b96fc750627459261e52e1190f6c"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3165,43 +3101,16 @@ dependencies = [
  "serde",
  "slab",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quic-rpc"
-version = "0.14.0"
-source = "git+https://github.com/n0-computer/quic-rpc?branch=naming-bikeshedding#d9637d1982e90c1ee6fb65a62f354fb319ebfb37"
-dependencies = [
- "anyhow",
- "bincode",
- "bytes",
- "derive_more",
- "educe",
- "flume",
- "futures-lite 2.4.0",
- "futures-sink",
- "futures-util",
- "hex",
- "hyper 0.14.31",
- "iroh-quinn",
- "pin-project",
- "serde",
- "slab",
- "tokio",
- "tokio-serde",
- "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "quic-rpc-derive"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403bc8506c847468e00170dbbbfe2c54d13b090031bcbe474cd3faea021cbd9f"
+version = "0.15.0"
+source = "git+https://github.com/n0-computer/quic-rpc?branch=map-transports-not-services#16b7c4942365b96fc750627459261e52e1190f6c"
 dependencies = [
  "proc-macro2",
- "quic-rpc 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quic-rpc",
  "quote",
  "syn 1.0.109",
 ]
@@ -3401,9 +3310,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -4337,21 +4246,6 @@ dependencies = [
  "url",
  "webpki-roots",
  "x509-parser",
-]
-
-[[package]]
-name = "tokio-serde"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
-dependencies = [
- "bincode",
- "bytes",
- "educe",
- "futures-core",
- "futures-sink",
- "pin-project",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ tracing = "0.1"
 
 # rpc dependencies (optional)
 nested_enum_utils = { version = "0.1.0", optional = true }
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "map-transports-not-services", optional = true }
-quic-rpc-derive = { git = "https://github.com/n0-computer/quic-rpc", branch = "map-transports-not-services", optional = true }
+quic-rpc = { version = "0.15.0", optional = true }
+quic-rpc-derive = { version = "0.15.0", optional = true }
 strum = { version = "0.26", optional = true }
 serde-error = "0.1.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tracing = "0.1"
 
 # rpc dependencies (optional)
 nested_enum_utils = { version = "0.1.0", optional = true }
-quic-rpc = { version = "0.13", optional = true }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "map-transports-not-services", optional = true }
 quic-rpc-derive = { version = "0.13", optional = true }
 strum = { version = "0.26", optional = true }
 serde-error = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ tracing = "0.1"
 
 # rpc dependencies (optional)
 nested_enum_utils = { version = "0.1.0", optional = true }
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "naming-bikeshedding", optional = true }
-quic-rpc-derive = { version = "0.14", optional = true }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "map-transports-not-services", optional = true }
+quic-rpc-derive = { git = "https://github.com/n0-computer/quic-rpc", branch = "map-transports-not-services", optional = true }
 strum = { version = "0.26", optional = true }
 serde-error = "0.1.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tracing = "0.1"
 
 # rpc dependencies (optional)
 nested_enum_utils = { version = "0.1.0", optional = true }
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "map-transports-not-services", optional = true }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "naming-bikeshedding", optional = true }
 quic-rpc-derive = { version = "0.14", optional = true }
 strum = { version = "0.26", optional = true }
 serde-error = "0.1.3"

--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,7 @@ allow = [
       "OpenSSL",
       "Unicode-DFS-2016",
       "Zlib",
+      "Unicode-3.0",
       "MPL-2.0", # https://fossa.com/blog/open-source-software-licenses-101-mozilla-public-license-2-0/
 ]
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,4 +1,6 @@
 //! Provides a rpc protocol as well as a client for the protocol
+use proto::RpcService;
+
 use crate::net::Gossip;
 pub use crate::net::{Command as SubscribeUpdate, Event as SubscribeResponse};
 pub mod client;
@@ -6,10 +8,13 @@ pub mod proto;
 
 impl Gossip {
     /// Handle a gossip request from the RPC server.
-    pub async fn handle_rpc_request<S: quic_rpc::Service, C: quic_rpc::ServiceEndpoint<S>>(
+    pub async fn handle_rpc_request<
+        S: quic_rpc::Service,
+        C: quic_rpc::ServiceEndpoint<RpcService>,
+    >(
         &self,
         msg: crate::rpc::proto::Request,
-        chan: quic_rpc::server::RpcChannel<crate::rpc::proto::RpcService, C, S>,
+        chan: quic_rpc::server::RpcChannel<RpcService, C>,
     ) -> Result<(), quic_rpc::server::RpcServerError<C>> {
         use quic_rpc::server::RpcServerError;
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,5 +1,6 @@
 //! Provides a rpc protocol as well as a client for the protocol
 use proto::RpcService;
+use quic_rpc::server::ChannelTypes;
 
 use crate::net::Gossip;
 pub use crate::net::{Command as SubscribeUpdate, Event as SubscribeResponse};
@@ -8,7 +9,7 @@ pub mod proto;
 
 impl Gossip {
     /// Handle a gossip request from the RPC server.
-    pub async fn handle_rpc_request<C: quic_rpc::ServiceChannel<RpcService>>(
+    pub async fn handle_rpc_request<C: ChannelTypes<RpcService>>(
         &self,
         msg: crate::rpc::proto::Request,
         chan: quic_rpc::server::RpcChannel<RpcService, C>,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -8,9 +8,7 @@ pub mod proto;
 
 impl Gossip {
     /// Handle a gossip request from the RPC server.
-    pub async fn handle_rpc_request<
-        C: quic_rpc::ServiceEndpoint<RpcService>,
-    >(
+    pub async fn handle_rpc_request<C: quic_rpc::ServiceChannel<RpcService>>(
         &self,
         msg: crate::rpc::proto::Request,
         chan: quic_rpc::server::RpcChannel<RpcService, C>,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -9,7 +9,6 @@ pub mod proto;
 impl Gossip {
     /// Handle a gossip request from the RPC server.
     pub async fn handle_rpc_request<
-        S: quic_rpc::Service,
         C: quic_rpc::ServiceEndpoint<RpcService>,
     >(
         &self,

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -18,8 +18,8 @@ use crate::{
 
 /// Iroh gossip client.
 #[derive(Debug, Clone)]
-pub struct Client<S = RpcService, C = BoxedServiceConnection<S>> {
-    pub(super) rpc: quic_rpc::RpcClient<RpcService, C, S>,
+pub struct Client<C = BoxedServiceConnection<RpcService>> {
+    pub(super) rpc: quic_rpc::RpcClient<RpcService, C>,
 }
 
 /// Options for subscribing to a gossip topic.
@@ -40,13 +40,12 @@ impl Default for SubscribeOpts {
     }
 }
 
-impl<S, C> Client<S, C>
+impl<C> Client<C>
 where
-    S: quic_rpc::Service,
-    C: quic_rpc::ServiceConnection<S>,
+    C: quic_rpc::ServiceConnection<RpcService>,
 {
     /// Creates a new gossip client.
-    pub fn new(rpc: quic_rpc::RpcClient<RpcService, C, S>) -> Self {
+    pub fn new(rpc: quic_rpc::RpcClient<RpcService, C>) -> Self {
         Self { rpc }
     }
 

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use futures_lite::{Stream, StreamExt};
 use futures_util::{Sink, SinkExt};
 use iroh_net::NodeId;
-use quic_rpc::client::BoxedServiceConnection;
+use quic_rpc::client::BoxedConnector;
 
 use crate::{
     net::{Command as SubscribeUpdate, Event as SubscribeResponse},
@@ -18,7 +18,7 @@ use crate::{
 
 /// Iroh gossip client.
 #[derive(Debug, Clone)]
-pub struct Client<C = BoxedServiceConnection<RpcService>> {
+pub struct Client<C = BoxedConnector<RpcService>> {
     pub(super) rpc: quic_rpc::RpcClient<RpcService, C>,
 }
 
@@ -42,7 +42,7 @@ impl Default for SubscribeOpts {
 
 impl<C> Client<C>
 where
-    C: quic_rpc::ServiceConnection<RpcService>,
+    C: quic_rpc::Connector<RpcService>,
 {
     /// Creates a new gossip client.
     pub fn new(rpc: quic_rpc::RpcClient<RpcService, C>) -> Self {


### PR DESCRIPTION
## Description

Use quic-rpc v0.15.0 and adapt API. Most notably we can get rid of an entire type parameter.

## Breaking Changes

Gossip::handle_rpc_request type parameters adapted to v0.15
rpc::client::Client type parameters adapted to v0.15
rpc::client::Client::new adapted to v0.15

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] ~~Tests if relevant.~~
- [x] All breaking changes documented.
