### PR TITLE
feat: Add in-memory rpc client and handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,8 +3086,9 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.15.0"
-source = "git+https://github.com/n0-computer/quic-rpc?branch=main#32d5bc1a08609f4f0b5650980088f07d81971a55"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc623a188942fc875926f7baeb2cb08ed4288b64f29072656eb051e360ee7623"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,8 +3087,7 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e131f594054d27d077162815db3b5e9ddd76a28fbb9091b68095971e75c286"
+source = "git+https://github.com/n0-computer/quic-rpc?branch=main#32d5bc1a08609f4f0b5650980088f07d81971a55"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3102,6 +3101,7 @@ dependencies = [
  "serde",
  "slab",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,3 +97,4 @@ rustdoc-args = ["--cfg", "iroh_docsrs"]
 [patch.crates-io]
 iroh-net = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-router = { git = "https://github.com/n0-computer/iroh", branch = "main" }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ tracing = "0.1"
 
 # rpc dependencies (optional)
 nested_enum_utils = { version = "0.1.0", optional = true }
-quic-rpc = { version = "0.15.0", optional = true }
+quic-rpc = { version = "0.15.1", optional = true }
 quic-rpc-derive = { version = "0.15.0", optional = true }
 strum = { version = "0.26", optional = true }
 serde-error = "0.1.3"
@@ -97,4 +97,3 @@ rustdoc-args = ["--cfg", "iroh_docsrs"]
 [patch.crates-io]
 iroh-net = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-router = { git = "https://github.com/n0-computer/iroh", branch = "main" }
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,7 @@ license-files = [
 [advisories]
 ignore = [
       "RUSTSEC-2024-0370", # unmaintained, no upgrade available
+      "RUSTSEC-2024-0384", # unmaintained, no upgrade available
 ]
 
 [sources]

--- a/src/net.rs
+++ b/src/net.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::{BTreeSet, HashMap, HashSet, VecDeque},
     pin::Pin,
-    sync::{Arc, OnceLock},
+    sync::Arc,
     task::{Context, Poll},
     time::Instant,
 };
@@ -93,7 +93,7 @@ pub struct Gossip {
     _actor_handle: Arc<AbortOnDropHandle<()>>,
     max_message_size: usize,
     #[cfg(feature = "rpc")]
-    pub(crate) rpc_handler: OnceLock<Arc<crate::rpc::RpcHandler>>,
+    pub(crate) rpc_handler: Arc<std::sync::OnceLock<crate::rpc::RpcHandler>>,
 }
 
 impl ProtocolHandler for Gossip {
@@ -146,7 +146,7 @@ impl Gossip {
             _actor_handle: Arc::new(AbortOnDropHandle::new(actor_handle)),
             max_message_size,
             #[cfg(feature = "rpc")]
-            rpc_handler: OnceLock::new(),
+            rpc_handler: Default::default(),
         }
     }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -145,7 +145,8 @@ impl Gossip {
             to_actor_tx,
             _actor_handle: Arc::new(AbortOnDropHandle::new(actor_handle)),
             max_message_size,
-            rpc_handler: Default::default(),
+            #[cfg(feature = "rpc")]
+            rpc_handler: OnceLock::new(),
         }
     }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::{BTreeSet, HashMap, HashSet, VecDeque},
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, OnceLock},
     task::{Context, Poll},
     time::Instant,
 };
@@ -92,6 +92,8 @@ pub struct Gossip {
     to_actor_tx: mpsc::Sender<ToActor>,
     _actor_handle: Arc<AbortOnDropHandle<()>>,
     max_message_size: usize,
+    #[cfg(feature = "rpc")]
+    pub(crate) rpc_handler: OnceLock<Arc<crate::rpc::RpcHandler>>,
 }
 
 impl ProtocolHandler for Gossip {
@@ -143,6 +145,7 @@ impl Gossip {
             to_actor_tx,
             _actor_handle: Arc::new(AbortOnDropHandle::new(actor_handle)),
             max_message_size,
+            rpc_handler: Default::default(),
         }
     }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,6 +1,4 @@
 //! Provides a rpc protocol as well as a client for the protocol
-use std::sync::Arc;
-
 use client::MemClient;
 use proto::{Request, Response, RpcService};
 use quic_rpc::{server::ChannelTypes, transport::flume::FlumeConnector, RpcClient, RpcServer};
@@ -75,7 +73,7 @@ impl Gossip {
     pub fn client(&self) -> &client::Client<FlumeConnector<Response, Request>> {
         let handler = self
             .rpc_handler
-            .get_or_init(|| Arc::new(RpcHandler::new(self)));
+            .get_or_init(|| RpcHandler::new(self));
         &handler.client
     }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,13 +1,84 @@
 //! Provides a rpc protocol as well as a client for the protocol
-use proto::RpcService;
-use quic_rpc::server::ChannelTypes;
+use std::sync::Arc;
+
+use client::Client;
+use proto::{Request, Response, RpcService};
+use quic_rpc::{server::ChannelTypes, transport::flume::FlumeConnector, RpcClient, RpcServer};
+use tokio::task::JoinSet;
+use tokio_util::task::AbortOnDropHandle;
+use tracing::{error, warn};
 
 use crate::net::Gossip;
 pub use crate::net::{Command as SubscribeUpdate, Event as SubscribeResponse};
 pub mod client;
 pub mod proto;
 
+#[derive(Debug)]
+pub(crate) struct RpcHandler {
+    /// Client to hand out
+    client: client::Client<FlumeConnector<Response, Request>>,
+    /// Handler task
+    _handler: AbortOnDropHandle<()>,
+}
+
+impl RpcHandler {
+    fn new(gossip: &Gossip) -> Self {
+        let gossip = gossip.clone();
+        let (listener, connector) = quic_rpc::transport::flume::channel(1);
+        let listener = RpcServer::<RpcService, _>::new(listener);
+        let client = Client::new(RpcClient::new(connector));
+        let task = tokio::spawn(async move {
+            let mut tasks = JoinSet::new();
+            loop {
+                tokio::select! {
+                    Some(res) = tasks.join_next(), if !tasks.is_empty() => {
+                        if let Err(e) = res {
+                            if e.is_panic() {
+                                error!("Panic in task: {e}");
+                            }
+                        }
+                    }
+                    req = listener.accept() => {
+                        let req = match req {
+                            Ok(req) => req,
+                            Err(e) => {
+                                warn!("Error accepting RPC request: {e}");
+                                continue;
+                            }
+                        };
+                        let gossip = gossip.clone();
+                        tasks.spawn(async move {
+                            let (req, client) = match req.read_first().await {
+                                Ok((req, client)) => (req, client),
+                                Err(e) => {
+                                    warn!("Error reading first message: {e}");
+                                    return;
+                                }
+                            };
+                            if let Err(cause) = gossip.handle_rpc_request(req, client).await {
+                                warn!("Error handling RPC request: {:?}", cause);
+                            }
+                        });
+                    }
+                }
+            }
+        });
+        Self {
+            client,
+            _handler: AbortOnDropHandle::new(task),
+        }
+    }
+}
+
 impl Gossip {
+    /// Get an in-memory gossip client
+    pub fn client(&self) -> &client::Client<FlumeConnector<Response, Request>> {
+        let handler = self
+            .rpc_handler
+            .get_or_init(|| Arc::new(RpcHandler::new(self)));
+        &handler.client
+    }
+
     /// Handle a gossip request from the RPC server.
     pub async fn handle_rpc_request<C: ChannelTypes<RpcService>>(
         &self,

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use futures_lite::{Stream, StreamExt};
 use futures_util::{Sink, SinkExt};
 use iroh_net::NodeId;
-use quic_rpc::client::BoxedConnector;
+use quic_rpc::{client::BoxedConnector, transport::flume::FlumeConnector};
 
 use crate::{
     net::{Command as SubscribeUpdate, Event as SubscribeResponse},
@@ -21,6 +21,10 @@ use crate::{
 pub struct Client<C = BoxedConnector<RpcService>> {
     pub(super) rpc: quic_rpc::RpcClient<RpcService, C>,
 }
+
+/// Type alias for a memory-backed client.
+pub type MemClient =
+    Client<FlumeConnector<crate::rpc::proto::Response, crate::rpc::proto::Request>>;
 
 /// Options for subscribing to a gossip topic.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Description

...lazily created so it doesn't cost much if you don't use it

## Breaking Changes

- handle_rpc_request takes self, not &self

## Notes & open questions

~~The RpcHandler stuff should be in quic-rpc maybe, or at least somehow DRYed.~~

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
