### PR TITLE
refactor!: align api naming between RPC and direct calls

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -140,7 +140,7 @@ async fn main() -> Result<()> {
             endpoint.add_node_addr(peer)?;
         }
     };
-    let (sender, receiver) = gossip.join(topic, peer_ids).await?.split();
+    let (sender, receiver) = gossip.subscribe_and_join(topic, peer_ids).await?.split();
     println!("> connected!");
 
     // broadcast our name, if set

--- a/src/net.rs
+++ b/src/net.rs
@@ -216,7 +216,7 @@ impl Gossip {
 
     /// Join a gossip topic with options and an externally-created update stream.
     ///
-    /// This method differs from [`Self::join_with_opts`] by letting you pass in a `updates` command stream yourself
+    /// This method differs from [`Self::subscribe_with_opts`] by letting you pass in a `updates` command stream yourself
     /// instead of using a channel created for you.
     ///
     /// It returns a stream of events. If you want to wait for the topic to become active, wait for

--- a/src/net.rs
+++ b/src/net.rs
@@ -194,11 +194,7 @@ impl Gossip {
     }
 
     /// Join a gossip topic with the default options.
-    pub async fn subscribe(
-        &self,
-        topic_id: TopicId,
-        bootstrap: Vec<NodeId>,
-    ) -> Result<GossipTopic> {
+    pub fn subscribe(&self, topic_id: TopicId, bootstrap: Vec<NodeId>) -> Result<GossipTopic> {
         let sub = self.subscribe_with_opts(topic_id, JoinOptions::with_bootstrap(bootstrap));
 
         Ok(sub)
@@ -1464,7 +1460,7 @@ mod test {
         let go1_task = async move {
             // first subscribe is done immediately
             tracing::info!("subscribing the first time");
-            let sub_1a = go1.subscribe(topic, vec![node_id2]).await;
+            let sub_1a = go1.subscribe_and_join(topic, vec![node_id2]).await;
 
             // wait for signal to subscribe a second time
             rx.recv().await.expect("signal for second subscribe");

--- a/src/net.rs
+++ b/src/net.rs
@@ -194,6 +194,8 @@ impl Gossip {
     }
 
     /// Join a gossip topic with the default options.
+    ///
+    /// Note that this will not wait for any bootstrap node to be available. To ensure the topic is connected to at least one node, use [`GossipTopic::joined`] or [`Gossip::subscribe_and_join`]
     pub fn subscribe(&self, topic_id: TopicId, bootstrap: Vec<NodeId>) -> Result<GossipTopic> {
         let sub = self.subscribe_with_opts(topic_id, JoinOptions::with_bootstrap(bootstrap));
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -49,7 +49,7 @@ impl Gossip {
             Subscribe(msg) => {
                 let this = self.clone();
                 chan.bidi_streaming(msg, this, move |handler, req, updates| {
-                    let stream = handler.join_with_stream(
+                    let stream = handler.subscribe_with_stream(
                         req.topic,
                         crate::net::JoinOptions {
                             bootstrap: req.bootstrap,


### PR DESCRIPTION
## Description

- make the `join` explicit 
- align API naming between RPC and direct calls

## Breaking Changes

- rename `net::Gossip::join` -> `net::Gossip::subscribe_and_join`
- added `net::Gossip::subscribe`
- rename `net::Gossip::join_with_opts` -> `net::Gossip::subscribe_with_opts` 
- rename `net::Gossip::join_with_stream` -> `net::Gossip::subscribe_with_stream` 

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
