### PR TITLE
fix: prevent task leak for rpc handler task

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,11 +1,13 @@
 //! Provides a rpc protocol as well as a client for the protocol
+use std::sync::Arc;
+
 use client::MemClient;
 use proto::{Request, Response, RpcService};
 use quic_rpc::{server::ChannelTypes, transport::flume::FlumeConnector, RpcClient, RpcServer};
 use tokio_util::task::AbortOnDropHandle;
 
-use crate::net::Gossip;
 pub use crate::net::{Command as SubscribeUpdate, Event as SubscribeResponse};
+use crate::net::{Gossip, Inner};
 pub mod client;
 pub mod proto;
 
@@ -18,7 +20,7 @@ pub(crate) struct RpcHandler {
 }
 
 impl RpcHandler {
-    fn new(gossip: &Gossip) -> Self {
+    fn new(gossip: Arc<Inner>) -> Self {
         let gossip = gossip.clone();
         let (listener, connector) = quic_rpc::transport::flume::channel(1);
         let listener = RpcServer::new(listener);
@@ -30,16 +32,9 @@ impl RpcHandler {
     }
 }
 
-impl Gossip {
-    /// Get an in-memory gossip client
-    pub fn client(&self) -> &client::Client<FlumeConnector<Response, Request>> {
-        let handler = self.rpc_handler.get_or_init(|| RpcHandler::new(self));
-        &handler.client
-    }
-
-    /// Handle a gossip request from the RPC server.
+impl Inner {
     pub async fn handle_rpc_request<C: ChannelTypes<RpcService>>(
-        self,
+        self: Arc<Self>,
         msg: Request,
         chan: quic_rpc::server::RpcChannel<RpcService, C>,
     ) -> Result<(), quic_rpc::server::RpcServerError<C>> {
@@ -63,5 +58,24 @@ impl Gossip {
             }
             Update(_msg) => Err(RpcServerError::UnexpectedUpdateMessage),
         }
+    }
+}
+
+impl Gossip {
+    /// Get an in-memory gossip client
+    pub fn client(&self) -> &client::Client<FlumeConnector<Response, Request>> {
+        let handler = self
+            .rpc_handler
+            .get_or_init(|| RpcHandler::new(self.inner.clone()));
+        &handler.client
+    }
+
+    /// Handle a gossip request from the RPC server.
+    pub async fn handle_rpc_request<C: ChannelTypes<RpcService>>(
+        self,
+        msg: Request,
+        chan: quic_rpc::server::RpcChannel<RpcService, C>,
+    ) -> Result<(), quic_rpc::server::RpcServerError<C>> {
+        self.inner.handle_rpc_request(msg, chan).await
     }
 }


### PR DESCRIPTION
## Description

There was a task leak because the lazily created rpc handler task was capturing an arced copy of the AbortOnDropHandle that keeps the task alive, so this task would never die. Also, this would keep alive the Gossip object forever *if* the lazy gossip task is started.

In this PR we introduce an Inner and make sure that the rpc handler only needs Inner, not full Gossip. That way we avoid the circular reference.

As a side benefit, we replace 2 arcs inside the Gossip with 1 arc for the Inner.

## Breaking Changes

None

## Notes & open questions

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
