### PR TITLE
add Sync bound to EventStream's inner

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -302,7 +302,7 @@ impl Inner {
 pub struct EventStream {
     /// The actual stream polled to return [`Event`]s to the application.
     #[debug("Stream")]
-    inner: Pin<Box<dyn Stream<Item = Result<Event>> + Send + 'static>>,
+    inner: Pin<Box<dyn Stream<Item = Result<Event>> + Send + Sync + 'static>>,
 
     /// Channel to the actor task.
     ///


### PR DESCRIPTION
## Description

v0.30.0 introduced a regression: the Rx side of a gossip subscription was no longer `Sync`. I believe this was simply do to a missed `+ Sync` bound.
I reintroduce that `+ Sync` bound, and my code from 0.29 starts compiling again.

## Notes & open questions
There's a PR open to fix this with a larger refactor, but I simply need the regression fixed :)

Feel free to close this PR if you'd rather just finish the refactor.

## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
