### PR TITLE
chore: patch to use main branch of iroh dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,8 +1704,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ffd6af2e000f04972068c0318e0d8fa90ee9cfcb2bc6124db38591500e0278"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#0c7a1227cf1b9f640145c059c7581f2c502e6691"
 dependencies = [
  "aead",
  "anyhow",
@@ -1764,14 +1763,12 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011d271a95b41218d22bdaf3352f29ef1dd7d6be644ca8543941655bec5f3d35"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#0c7a1227cf1b9f640145c059c7581f2c502e6691"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
  "derive_more",
  "ed25519-dalek",
- "getrandom 0.2.15",
  "rand_core 0.6.4",
  "serde",
  "thiserror 2.0.11",
@@ -1853,8 +1850,7 @@ dependencies = [
 [[package]]
 name = "iroh-net-report"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2652f42eadc63458e36c0a422569f338639dc0b5bb469db0eb4a382b4e295c"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#0c7a1227cf1b9f640145c059c7581f2c502e6691"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1937,8 +1933,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c930ccc4dfd0196b531344e3d0f83a0f82c45b170406e04a2491cba571faec5b"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#0c7a1227cf1b9f640145c059c7581f2c502e6691"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2905,8 +2900,7 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ac46017d97c2ee3a7013c256a8ed00748b685ad8235f52245eb894706959c5"
+source = "git+https://github.com/n0-computer/quic-rpc.git?branch=main#ec27edbc1cba730d8bf54a61be06ffc62df3948e"
 dependencies = [
  "anyhow",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,3 +113,7 @@ required-features = ["examples"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "iroh_docsrs"]
+
+[patch.crates-io]
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -33,3 +33,6 @@ license-files = [
 ignore = [
       "RUSTSEC-2024-0384", # unmaintained, no upgrade available
 ]
+
+[sources]
+allow-git = ["https://github.com/n0-computer/iroh.git", "https://github.com/n0-computer/quic-rpc.git"]


### PR DESCRIPTION
This PR updates the following dependencies to use their main branches:

- `iroh` from `https://github.com/n0-computer/iroh.git`
- `quic-rpc` from `https://github.com/n0-computer/quic-rpc.git`