### PR TITLE
fix: allow instant reconnects, and always prefer newest connection

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -1287,7 +1287,8 @@ mod test {
 
     use bytes::Bytes;
     use futures_concurrency::future::TryJoin;
-    use iroh::{RelayMap, RelayMode, SecretKey};
+    use iroh::{protocol::Router, RelayMap, RelayMode, SecretKey};
+    use rand::Rng;
     use tokio::{spawn, time::timeout};
     use tokio_util::sync::CancellationToken;
     use tracing::{info, instrument};
@@ -1815,5 +1816,134 @@ mod test {
         timeout(wait, go2_handle).await???;
 
         testresult::TestResult::Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn can_die_and_reconnect() -> testresult::TestResult {
+        /// Runs a future in a separate runtime on a separate thread, cancelling everything
+        /// abruptly once `cancel` is invoked.
+        fn run_in_thread<T: Send + 'static>(
+            cancel: CancellationToken,
+            fut: impl std::future::Future<Output = T> + Send + 'static,
+        ) -> std::thread::JoinHandle<Option<T>> {
+            std::thread::spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                rt.block_on(async move { cancel.run_until_cancelled(fut).await })
+            })
+        }
+
+        /// Spawns a new endpoint and gossip instance.
+        async fn spawn_gossip(
+            secret_key: SecretKey,
+            relay_map: RelayMap,
+        ) -> anyhow::Result<(Router, Gossip)> {
+            let ep = Endpoint::builder()
+                .secret_key(secret_key)
+                .relay_mode(RelayMode::Custom(relay_map))
+                .insecure_skip_relay_cert_verify(true)
+                .bind()
+                .await?;
+            let gossip = Gossip::builder().spawn(ep.clone()).await?;
+            let router = Router::builder(ep.clone())
+                .accept(GOSSIP_ALPN, gossip.clone())
+                .spawn()
+                .await?;
+            Ok((router, gossip))
+        }
+
+        /// Spawns a gossip node, and broadcasts a single message, then sleep until cancelled externally.
+        async fn broadcast_once(
+            secret_key: SecretKey,
+            relay_map: RelayMap,
+            bootstrap: NodeAddr,
+            topic_id: TopicId,
+            message: String,
+        ) -> anyhow::Result<()> {
+            let (router, gossip) = spawn_gossip(secret_key, relay_map).await?;
+            let node_id = bootstrap.node_id;
+            router.endpoint().add_node_addr(bootstrap)?;
+            let topic = gossip.subscribe_and_join(topic_id, vec![node_id]).await?;
+            topic.broadcast(message.as_bytes().to_vec().into()).await?;
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+
+        let (relay_map, _relay_url, _guard) = iroh::test_utils::run_relay_server().await.unwrap();
+        let mut rng = &mut rand_chacha::ChaCha12Rng::seed_from_u64(1);
+        let topic_id = TopicId::from_bytes(rng.gen());
+
+        // spawn a gossip node, send the node's address on addr_tx,
+        // then wait to receive `count` messages, and terminate.
+        let (addr_tx, addr_rx) = tokio::sync::oneshot::channel();
+        let (msgs_recv_tx, mut msgs_recv_rx) = tokio::sync::mpsc::channel(3);
+        let recv_task = tokio::task::spawn({
+            let relay_map = relay_map.clone();
+            let secret_key = SecretKey::generate(&mut rng);
+            async move {
+                let (router, gossip) = spawn_gossip(secret_key, relay_map).await?;
+                let addr = router.endpoint().node_addr().await?;
+                addr_tx.send(addr).unwrap();
+                let mut topic = gossip.subscribe_and_join(topic_id, vec![]).await?;
+                while let Some(event) = topic.try_next().await.unwrap() {
+                    if let Event::Gossip(GossipEvent::Received(message)) = event {
+                        let message = std::str::from_utf8(&message.content)?.to_string();
+                        msgs_recv_tx.send(message).await?;
+                    }
+                }
+                anyhow::Ok(())
+            }
+        });
+
+        let node0_addr = addr_rx.await?;
+        info!("n0: node addr {node0_addr:?}");
+
+        let max_wait = Duration::from_secs(5);
+
+        // spawn a node, send a message, and then abruptly terminate the node ungracefully
+        // after the message was received on our receiver node.
+        let cancel = CancellationToken::new();
+        let secret = SecretKey::generate(&mut rng);
+        let join_handle_1 = run_in_thread(
+            cancel.clone(),
+            broadcast_once(
+                secret.clone(),
+                relay_map.clone(),
+                node0_addr.clone(),
+                topic_id,
+                "msg1".to_string(),
+            ),
+        );
+        // assert that we received the message on the receiver node.
+        let msg = timeout(max_wait, msgs_recv_rx.recv()).await?.unwrap();
+        assert_eq!(&msg, "msg1");
+        cancel.cancel();
+
+        // spawns the node again with the same node id, and send another message
+        let cancel = CancellationToken::new();
+        let join_handle_2 = run_in_thread(
+            cancel.clone(),
+            broadcast_once(
+                secret.clone(),
+                relay_map.clone(),
+                node0_addr.clone(),
+                topic_id,
+                "msg2".to_string(),
+            ),
+        );
+        // assert that we received the message on the receiver node.
+        // this means that the reconnect with the same node id worked.
+        let msg = timeout(max_wait, msgs_recv_rx.recv()).await?.unwrap();
+        assert_eq!(&msg, "msg2");
+        cancel.cancel();
+
+        recv_task.abort();
+        assert!(join_handle_1.join().unwrap().is_none());
+        assert!(join_handle_2.join().unwrap().is_none());
+
+        Ok(())
     }
 }

--- a/src/proto/state.rs
+++ b/src/proto/state.rs
@@ -207,7 +207,7 @@ impl<PI: PeerIdentity, R: Rng + Clone> State<PI, R> {
         event: InEvent<PI>,
         now: Instant,
     ) -> impl Iterator<Item = OutEvent<PI>> + '_ {
-        trace!("gossp event: {event:?}");
+        trace!("in_event: {event:?}");
         track_in_event(&event);
 
         let event: InEventMapped<PI> = event.into();
@@ -274,6 +274,7 @@ fn handle_out_event<PI: PeerIdentity>(
     conns: &mut ConnsMap<PI>,
     outbox: &mut Outbox<PI>,
 ) {
+    trace!("out_event: {event:?}");
     match event {
         topic::OutEvent::SendMessage(to, message) => {
             outbox.push(OutEvent::SendMessage(to, Message { topic, message }))


### PR DESCRIPTION
## Description

This should fix #10. It has two changes:

* On `main`, new incoming connections are rejected unless an old incoming connection timed out or are closed properly. This logic was most recently adapted in #22. The current situation is not ideal, because it means that if a peer reconnects without closing the previous connection properly, the new connection will be rejected. This PR changes the logic so that *all* incoming connections are accepted, and we *always* use the newest connection for sending messages. When a new connection is accepted, old connections are not aborted immediately. Instead we close our send stream on the old connection, which makes the peer close its receive stream. If the peer also uses the new connection only, the connection will close on our side as well. This means that multiple connections can coexist, which is maybe not ideal but also not harmful I think. A peer is marked as disconnected for the gossip state machine only when *all* connections to the peer are terminated.

* The hyparview implementation only replied to `Join` messages if the joining peer was not in the receiver's set of active nodes. This means that when a node reconnects, it would not receive a reply unless the receiving node had already detected a timeout on the previous connections and removed the peer from their active nodes. In the case of an ungraceful shutdown, this only happens after the connection times out after 30s with default transport parameters. This PR changes the hyparview implementation to *always* reply to `Join` messages with a `Neighbor` message, also in the case that the joining node is already in the set of active nodes. The same change is applied to receiving `ForwardJoin` . This should have no downsides, as in the regular protocol flow `Join` messages are only sent when first joining nodes. The `Neighbor` reply for nodes that are already active can be a considered a informative renewal of the existing neighbor relation. This fixes the reconnect issue even when connections are not yet timed out.

* Adds a test for this scenario by spawning a gossip node on a single-threaded runtime that can be aborted abrpuply, and then a node with the same node id spawned and connected to the same bootstrap node. The test passes here and fails on main (see #44).

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
