### PR TITLE
refactor: improve disconnection logic in hyparview implementation

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -1287,7 +1287,8 @@ mod test {
 
     use bytes::Bytes;
     use futures_concurrency::future::TryJoin;
-    use iroh::{RelayMap, RelayMode, SecretKey};
+    use iroh::{protocol::Router, RelayMap, RelayMode, SecretKey};
+    use rand::Rng;
     use tokio::{spawn, time::timeout};
     use tokio_util::sync::CancellationToken;
     use tracing::{info, instrument};
@@ -1815,5 +1816,134 @@ mod test {
         timeout(wait, go2_handle).await???;
 
         testresult::TestResult::Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn can_die_and_reconnect() -> testresult::TestResult {
+        /// Runs a future in a separate runtime on a separate thread, cancelling everything
+        /// abruptly once `cancel` is invoked.
+        fn run_in_thread<T: Send + 'static>(
+            cancel: CancellationToken,
+            fut: impl std::future::Future<Output = T> + Send + 'static,
+        ) -> std::thread::JoinHandle<Option<T>> {
+            std::thread::spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                rt.block_on(async move { cancel.run_until_cancelled(fut).await })
+            })
+        }
+
+        /// Spawns a new endpoint and gossip instance.
+        async fn spawn_gossip(
+            secret_key: SecretKey,
+            relay_map: RelayMap,
+        ) -> anyhow::Result<(Router, Gossip)> {
+            let ep = Endpoint::builder()
+                .secret_key(secret_key)
+                .relay_mode(RelayMode::Custom(relay_map))
+                .insecure_skip_relay_cert_verify(true)
+                .bind()
+                .await?;
+            let gossip = Gossip::builder().spawn(ep.clone()).await?;
+            let router = Router::builder(ep.clone())
+                .accept(GOSSIP_ALPN, gossip.clone())
+                .spawn()
+                .await?;
+            Ok((router, gossip))
+        }
+
+        /// Spawns a gossip node, and broadcasts a single message, then sleep until cancelled externally.
+        async fn broadcast_once(
+            secret_key: SecretKey,
+            relay_map: RelayMap,
+            bootstrap: NodeAddr,
+            topic_id: TopicId,
+            message: String,
+        ) -> anyhow::Result<()> {
+            let (router, gossip) = spawn_gossip(secret_key, relay_map).await?;
+            let node_id = bootstrap.node_id;
+            router.endpoint().add_node_addr(bootstrap)?;
+            let topic = gossip.subscribe_and_join(topic_id, vec![node_id]).await?;
+            topic.broadcast(message.as_bytes().to_vec().into()).await?;
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+
+        let (relay_map, _relay_url, _guard) = iroh::test_utils::run_relay_server().await.unwrap();
+        let mut rng = &mut rand_chacha::ChaCha12Rng::seed_from_u64(1);
+        let topic_id = TopicId::from_bytes(rng.gen());
+
+        // spawn a gossip node, send the node's address on addr_tx,
+        // then wait to receive `count` messages, and terminate.
+        let (addr_tx, addr_rx) = tokio::sync::oneshot::channel();
+        let (msgs_recv_tx, mut msgs_recv_rx) = tokio::sync::mpsc::channel(3);
+        let recv_task = tokio::task::spawn({
+            let relay_map = relay_map.clone();
+            let secret_key = SecretKey::generate(&mut rng);
+            async move {
+                let (router, gossip) = spawn_gossip(secret_key, relay_map).await?;
+                let addr = router.endpoint().node_addr().await?;
+                addr_tx.send(addr).unwrap();
+                let mut topic = gossip.subscribe_and_join(topic_id, vec![]).await?;
+                while let Some(event) = topic.try_next().await.unwrap() {
+                    if let Event::Gossip(GossipEvent::Received(message)) = event {
+                        let message = std::str::from_utf8(&message.content)?.to_string();
+                        msgs_recv_tx.send(message).await?;
+                    }
+                }
+                anyhow::Ok(())
+            }
+        });
+
+        let node0_addr = addr_rx.await?;
+        info!("n0: node addr {node0_addr:?}");
+
+        let max_wait = Duration::from_secs(5);
+
+        // spawn a node, send a message, and then abruptly terminate the node ungracefully
+        // after the message was received on our receiver node.
+        let cancel = CancellationToken::new();
+        let secret = SecretKey::generate(&mut rng);
+        let join_handle_1 = run_in_thread(
+            cancel.clone(),
+            broadcast_once(
+                secret.clone(),
+                relay_map.clone(),
+                node0_addr.clone(),
+                topic_id,
+                "msg1".to_string(),
+            ),
+        );
+        // assert that we received the message on the receiver node.
+        let msg = timeout(max_wait, msgs_recv_rx.recv()).await?.unwrap();
+        assert_eq!(&msg, "msg1");
+        cancel.cancel();
+
+        // spawns the node again with the same node id, and send another message
+        let cancel = CancellationToken::new();
+        let join_handle_2 = run_in_thread(
+            cancel.clone(),
+            broadcast_once(
+                secret.clone(),
+                relay_map.clone(),
+                node0_addr.clone(),
+                topic_id,
+                "msg2".to_string(),
+            ),
+        );
+        // assert that we received the message on the receiver node.
+        // this means that the reconnect with the same node id worked.
+        let msg = timeout(max_wait, msgs_recv_rx.recv()).await?.unwrap();
+        assert_eq!(&msg, "msg2");
+        cancel.cancel();
+
+        recv_task.abort();
+        assert!(join_handle_1.join().unwrap().is_none());
+        assert!(join_handle_2.join().unwrap().is_none());
+
+        Ok(())
     }
 }

--- a/src/proto/hyparview.rs
+++ b/src/proto/hyparview.rs
@@ -84,8 +84,6 @@ pub enum Message<PI> {
     /// Request to disconnect from a peer.
     /// If [`Disconnect::alive`] is true, the other peer is not shutting down, so it should be
     /// added to the passive set.
-    /// If [`Disconnect::respond`] is true, the peer should answer the disconnect request
-    /// before shutting down the connection.
     Disconnect(Disconnect),
 }
 
@@ -165,9 +163,9 @@ pub struct Neighbor {
 pub struct Disconnect {
     /// Whether we are actually shutting down or closing the connection only because our limits are
     /// reached.
-    alive: Alive,
-    /// Whether we should reply to the peer with a Disconnect message.
-    respond: Respond,
+    alive: bool,
+    /// Obsolete field (kept in the struct to not break wire compatibility).
+    _respond: bool,
 }
 
 /// Configuration for the swarm membership layer
@@ -221,9 +219,6 @@ impl Default for Config {
     }
 }
 
-pub type Respond = bool;
-pub type Alive = bool;
-
 #[derive(Default, Debug, Clone)]
 pub struct Stats {
     total_connections: usize,
@@ -252,6 +247,8 @@ pub struct State<PI, RG = ThreadRng> {
     pending_neighbor_requests: HashSet<PI>,
     /// The opaque user peer data we received for other peers
     peer_data: HashMap<PI, PeerData>,
+    /// List of peers that are disconnecting, but which we want to keep in the passive set once the connection closes
+    alive_disconnect_peers: HashSet<PI>,
 }
 
 impl<PI, RG> State<PI, RG>
@@ -271,6 +268,7 @@ where
             stats: Stats::default(),
             pending_neighbor_requests: Default::default(),
             peer_data: Default::default(),
+            alive_disconnect_peers: Default::default(),
         }
     }
 
@@ -281,7 +279,7 @@ where
                 Timer::DoShuffle => self.handle_shuffle_timer(io),
                 Timer::PendingNeighborRequest(peer) => self.handle_pending_neighbor_timer(peer, io),
             },
-            InEvent::PeerDisconnected(peer) => self.handle_disconnect(peer, io),
+            InEvent::PeerDisconnected(peer) => self.handle_connection_closed(peer, io),
             InEvent::RequestJoin(peer) => self.handle_join(peer, io),
             InEvent::UpdatePeerData(data) => {
                 self.me_data = Some(data);
@@ -332,28 +330,39 @@ where
         ));
     }
 
-    fn handle_disconnect(&mut self, peer: PI, io: &mut impl IO<PI>) {
-        self.on_disconnect(
-            peer,
-            Disconnect {
-                alive: true,
-                respond: false,
-            },
-            io,
-        );
+    fn on_disconnect(&mut self, peer: PI, details: Disconnect, io: &mut impl IO<PI>) {
+        self.pending_neighbor_requests.remove(&peer);
+        if self.active_view.contains(&peer) {
+            self.remove_active(&peer, RemovalReason::DisconnectReceived(details.alive), io);
+        } else if details.alive && self.passive_view.contains(&peer) {
+            self.alive_disconnect_peers.insert(peer);
+        }
+    }
+
+    fn handle_connection_closed(&mut self, peer: PI, io: &mut impl IO<PI>) {
+        self.pending_neighbor_requests.remove(&peer);
+        if self.active_view.contains(&peer) {
+            self.remove_active(&peer, RemovalReason::ConnectionClosed, io);
+        } else if !self.alive_disconnect_peers.remove(&peer) {
+            self.passive_view.remove(&peer);
+            self.peer_data.remove(&peer);
+        }
     }
 
     fn handle_quit(&mut self, io: &mut impl IO<PI>) {
         for peer in self.active_view.clone().into_iter() {
-            self.on_disconnect(
-                peer,
-                Disconnect {
-                    alive: false,
-                    respond: true,
-                },
-                io,
-            );
+            self.active_view.remove(&peer);
+            self.send_disconnect(peer, false, io);
         }
+    }
+
+    fn send_disconnect(&self, peer: PI, alive: bool, io: &mut impl IO<PI>) {
+        let message = Message::Disconnect(Disconnect {
+            alive,
+            _respond: false,
+        });
+        io.push(OutEvent::SendMessage(peer, message));
+        io.push(OutEvent::DisconnectPeer(peer));
     }
 
     fn on_join(&mut self, peer: PI, data: Option<PeerData>, now: Instant, io: &mut impl IO<PI>) {
@@ -510,18 +519,6 @@ where
         }
     }
 
-    fn on_disconnect(&mut self, peer: PI, details: Disconnect, io: &mut impl IO<PI>) {
-        self.pending_neighbor_requests.remove(&peer);
-        self.remove_active(&peer, details.respond, io);
-        if details.alive {
-            if let Some(data) = self.peer_data.remove(&peer) {
-                self.add_passive(peer, Some(data), io);
-            }
-        } else {
-            self.passive_view.remove(&peer);
-        }
-    }
-
     fn handle_shuffle_timer(&mut self, io: &mut impl IO<PI>) {
         if let Some(node) = self.active_view.pick_random(&mut self.rng) {
             let active = self.active_view.shuffled_without_and_capped(
@@ -578,16 +575,11 @@ where
     /// Remove a peer from the active view.
     ///
     /// If respond is true, a Disconnect message will be sent to the peer.
-    fn remove_active(&mut self, peer: &PI, respond: Respond, io: &mut impl IO<PI>) -> Option<PI> {
-        self.active_view.get_index_of(peer).map(|idx| {
-            let removed_peer = self
-                .remove_active_by_index(idx, respond, RemovalReason::Disconnect, io)
-                .unwrap();
-
+    fn remove_active(&mut self, peer: &PI, reason: RemovalReason, io: &mut impl IO<PI>) {
+        if let Some(idx) = self.active_view.get_index_of(peer) {
+            let removed_peer = self.remove_active_by_index(idx, reason, io).unwrap();
             self.refill_active_from_passive(&[&removed_peer], io);
-
-            removed_peer
-        })
+        }
     }
 
     fn refill_active_from_passive(&mut self, skip_peers: &[&PI], io: &mut impl IO<PI>) {
@@ -638,22 +630,38 @@ where
     fn remove_active_by_index(
         &mut self,
         peer_index: usize,
-        respond: Respond,
         reason: RemovalReason,
         io: &mut impl IO<PI>,
     ) -> Option<PI> {
         if let Some(peer) = self.active_view.remove_index(peer_index) {
-            if respond {
-                let message = Message::Disconnect(Disconnect {
-                    alive: true,
-                    respond: false,
-                });
-                io.push(OutEvent::SendMessage(peer, message));
-            }
-            io.push(OutEvent::DisconnectPeer(peer));
             io.push(OutEvent::EmitEvent(Event::NeighborDown(peer)));
-            let data = self.peer_data.remove(&peer);
-            self.add_passive(peer, data, io);
+
+            match reason {
+                // send a disconnect message, then close connection.
+                RemovalReason::Random => self.send_disconnect(peer, true, io),
+                // close connection without sending anything further.
+                RemovalReason::DisconnectReceived(_) => io.push(OutEvent::DisconnectPeer(peer)),
+                // do nothing, connection already closed.
+                RemovalReason::ConnectionClosed => {}
+            }
+
+            let keep_alive_as_passive = match reason {
+                // keep alive if previously marked as alive.
+                RemovalReason::ConnectionClosed => self.alive_disconnect_peers.remove(&peer),
+                // keep alive if other peer said to be still alive.
+                RemovalReason::DisconnectReceived(alive) => alive,
+                // keep alive (only we are removing for now)
+                RemovalReason::Random => true,
+            };
+
+            if keep_alive_as_passive {
+                let data = self.peer_data.remove(&peer);
+                self.add_passive(peer, data, io);
+                // mark peer as alive, so it doesn't get removed from the passive view if the conn closes.
+                if !matches!(reason, RemovalReason::ConnectionClosed) {
+                    self.alive_disconnect_peers.insert(peer);
+                }
+            }
             debug!(other = ?peer, "removed from active view, reason: {reason:?}");
             Some(peer)
         } else {
@@ -664,7 +672,7 @@ where
     /// Remove a random peer from the active view.
     fn free_random_slot_in_active_view(&mut self, io: &mut impl IO<PI>) {
         if let Some(index) = self.active_view.pick_random_index(&mut self.rng) {
-            self.remove_active_by_index(index, true, RemovalReason::Random, io);
+            self.remove_active_by_index(index, RemovalReason::Random, io);
         }
     }
 
@@ -721,6 +729,7 @@ where
 
 #[derive(Debug)]
 enum RemovalReason {
-    Disconnect,
+    ConnectionClosed,
+    DisconnectReceived(bool),
     Random,
 }

--- a/src/proto/state.rs
+++ b/src/proto/state.rs
@@ -207,7 +207,7 @@ impl<PI: PeerIdentity, R: Rng + Clone> State<PI, R> {
         event: InEvent<PI>,
         now: Instant,
     ) -> impl Iterator<Item = OutEvent<PI>> + '_ {
-        trace!("gossp event: {event:?}");
+        trace!("in_event: {event:?}");
         track_in_event(&event);
 
         let event: InEventMapped<PI> = event.into();
@@ -274,6 +274,7 @@ fn handle_out_event<PI: PeerIdentity>(
     conns: &mut ConnsMap<PI>,
     outbox: &mut Outbox<PI>,
 ) {
+    trace!("out_event: {event:?}");
     match event {
         topic::OutEvent::SendMessage(to, message) => {
             outbox.push(OutEvent::SendMessage(to, Message { topic, message }))


### PR DESCRIPTION
## Description

This improves how Disconnect messages and closed connections are handled in the `hyparview` implementation.

* Deprecate unused `respond` field in `Disconnect` messages  (it's not removed to not break the wire protocol)
* Mark nodes that reported `alive: true` in a Disconnect messages, so that they are not removed from the passive view once the connection closes
* Streamline logic around disconnects

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
