### PR TITLE
change: only add peers to the active view after receiving a neighbor message

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -613,6 +613,12 @@ impl Actor {
                     Some(Err(err)) => {
                         warn!(peer = %peer_id.fmt_short(), "dial failed: {err}");
                         inc!(Metrics, actor_tick_dialer_failure);
+                        let peer_state = self.peers.get(&peer_id);
+                        let is_active = matches!(peer_state, Some(PeerState::Active { .. }));
+                        if !is_active {
+                            self.handle_in_event(InEvent::PeerDisconnected(peer_id), Instant::now())
+                                .await?;
+                        }
                     }
                     None => {
                         warn!(peer = %peer_id.fmt_short(), "dial disconnected");

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -178,7 +178,7 @@ mod test {
         // Now let node 3 join node 0.
         // Node 0 is full, so it will disconnect from either node 1 or node 2.
         network.command(3, t, Command::Join(vec![0]));
-        network.ticks(8);
+        network.ticks(10);
 
         // Confirm emitted events. There's two options because whether node 0 disconnects from
         // node 1 or node 2 is random.
@@ -213,7 +213,7 @@ mod test {
         let config = Config::default();
         let mut network = Network::new(Instant::now());
         let broadcast_ticks = 12;
-        let join_ticks = 12;
+        let join_ticks = 13;
         // build a network with 6 nodes
         let rng = rand_chacha::ChaCha12Rng::seed_from_u64(99);
         for i in 0..6 {

--- a/src/proto/state.rs
+++ b/src/proto/state.rs
@@ -207,7 +207,7 @@ impl<PI: PeerIdentity, R: Rng + Clone> State<PI, R> {
         event: InEvent<PI>,
         now: Instant,
     ) -> impl Iterator<Item = OutEvent<PI>> + '_ {
-        trace!("in_event: {event:?}");
+        trace!("in : {event:?}");
         track_in_event(&event);
 
         let event: InEventMapped<PI> = event.into();
@@ -274,7 +274,7 @@ fn handle_out_event<PI: PeerIdentity>(
     conns: &mut ConnsMap<PI>,
     outbox: &mut Outbox<PI>,
 ) {
-    trace!("out_event: {event:?}");
+    trace!("out: {event:?}");
     match event {
         topic::OutEvent::SendMessage(to, message) => {
             outbox.push(OutEvent::SendMessage(to, Message { topic, message }))


### PR DESCRIPTION
## Description

This is a change in behavior of hyparview. Currently, and according to the paper, peers are added to a node's active view directly after receiving a `ForwardJoin` for the peer. This means that a peer is added without knowing if the peer is reachable or online. This PR changes this behavior so that on `ForwardJoin`, we send out a `Neighbor` message, but wait until we receive the `Neighbor` reply to add the peer to our active view. The PR also forward failed dial events to the protocol state, to clean up state.

A consequence is that the joining phase after a `ForwardJoin` takes one roundtrip to complete, whereas before we would start sending messages to our new peer right after the connection is established. I think this delay is worth the gained assurance that `NeighborUp` events are only emitted for peers that we can actually talk to.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
