### PR TITLE
feat/fix: Protocol improvements and fixes

### DIFF
--- a/src/proto/hyparview.rs
+++ b/src/proto/hyparview.rs
@@ -518,6 +518,7 @@ where
         for node in message.nodes {
             self.add_passive(node.id, node.data, io);
         }
+        self.refill_active_from_passive(&[], io);
     }
 
     fn handle_shuffle_timer(&mut self, io: &mut impl IO<PI>) {
@@ -536,6 +537,11 @@ where
                 .iter()
                 .chain(passive.iter())
                 .map(|id| self.peer_info(id));
+            let me = PeerInfo {
+                id: self.me,
+                data: self.me_data.clone(),
+            };
+            let nodes = nodes.chain([me]);
             let message = Shuffle {
                 origin: self.me,
                 nodes: nodes.collect(),

--- a/src/proto/hyparview.rs
+++ b/src/proto/hyparview.rs
@@ -319,6 +319,7 @@ where
         }
 
         // Disconnect from passive nodes right after receiving a message.
+        // TODO(frando): I'm not sure anymore that this is correct. Maybe remove?
         if !is_disconnect && !self.active_view.contains(&from) {
             io.push(OutEvent::DisconnectPeer(from));
         }
@@ -480,7 +481,7 @@ where
         if let Some(data) = peer_info.data {
             let old = self.peer_data.remove(&peer_info.id);
             let same = matches!(old, Some(old) if old == data);
-            if !same {
+            if !same && !data.0.is_empty() {
                 io.push(OutEvent::PeerData(peer_info.id, data.clone()));
             }
             self.peer_data.insert(peer_info.id, data);

--- a/src/proto/plumtree.rs
+++ b/src/proto/plumtree.rs
@@ -615,6 +615,7 @@ impl<PI: PeerIdentity> State<PI> {
 
     /// A scheduled [`Timer::SendGraft`] has reached it's deadline.
     fn on_send_graft_timer(&mut self, id: MessageId, io: &mut impl IO<PI>) {
+        self.graft_timer_scheduled.remove(&id);
         // if the message was received before the timer ran out, there is no need to request it
         // again
         if self.received_messages.contains_key(&id) {

--- a/src/proto/plumtree.rs
+++ b/src/proto/plumtree.rs
@@ -571,9 +571,11 @@ impl<PI: PeerIdentity> State<PI> {
                         id: None,
                         round: ihave_round,
                     });
+                    self.add_eager(ihave_peer);
                     io.push(OutEvent::SendMessage(ihave_peer, message));
                 }
                 // Prune the sender of the Gossip.
+                self.add_lazy(*gossip_sender);
                 io.push(OutEvent::SendMessage(*gossip_sender, Message::Prune));
             }
         }

--- a/tests/sim.rs
+++ b/tests/sim.rs
@@ -1,3 +1,5 @@
+//! Tests that use the [`iroh_gossip::proto::sim::Simulator`].
+
 use std::{env, fmt, str::FromStr, time::Duration};
 
 use iroh_gossip::proto::{
@@ -26,7 +28,6 @@ fn big_hyparview() {
 
 #[test]
 // #[traced_test]
-#[ignore = "currently failing, will be fixed with https://github.com/n0-computer/iroh-gossip/pull/53"]
 fn big_multiple_sender() {
     tracing_subscriber::fmt::try_init().ok();
 
@@ -59,7 +60,6 @@ fn big_multiple_sender() {
 
 #[test]
 // #[traced_test]
-#[ignore = "currently failing, will be fixed with https://github.com/n0-computer/iroh-gossip/pull/53"]
 fn big_single_sender() {
     tracing_subscriber::fmt::try_init().ok();
 
@@ -91,7 +91,6 @@ fn big_single_sender() {
 
 #[test]
 // #[traced_test]
-#[ignore = "currently failing, will be fixed with https://github.com/n0-computer/iroh-gossip/pull/53"]
 fn big_burst() {
     tracing_subscriber::fmt::try_init().ok();
     let network_config = NetworkConfig::default();


### PR DESCRIPTION
## Description

This PR combines the "protocol improvements" PRs into one. See the individual commit messages for details.
Combined, these commits improve the reliability and behavior of the swarm layer (hyparview) significantly.


**refactor(hyparview): Improve disconnect handling**
5156d00f72be478872e7cecdf1b95d739b3b4fca
    
This improves the abstractions around when Disconnect messages are sent
and when peers are disconnected. Through a new RemovalReason enum, we
can handle this much cleaner. We also store in the local state if we
intended to disconnect from a peer, to not remove that peer from our
passive view once the peer is actually disconnected on the network layer.

**fix(hyparview)!: Only add peers to active view after receiving neighbor messages (#56)**
5a441e6cf5589fc3c7cf3c290005b1094895038c

This is a change in behavior of hyparview. Currently, and according to the paper,
peers are added to a node's active view directly after receiving a ForwardJoin
for the peer. This means that a peer is added without knowing if the peer is
reachable or online. This PR changes this behavior so that on ForwardJoin,
we send out a Neighbor message, but wait until we receive the Neighbor reply
to add the peer to our active view. The PR also forward failed dial events to
the protocol state, to clean up state.

A consequence is that the joining phase after a ForwardJoin takes one roundtrip
to complete, whereas before we would start sending messages to our new peer right
after the connection is established. I think this delay is worth the gained assurance
that NeighborUp events are only emitted for peers that we can actually talk to.

This substantially improves the protocol according to simulations, as we
don't collect stale peers in our active view.

While this is not a wire- or API-breaking change, this changes the
behavior as to which messages are sent out when. While I *think* that
nodes before and after this change will work well together, we did not
verify or test this yet.

**fix(hyparview): Use shuffle replies as intended (#57)**
9632ced028ad7c211ac256b89d7ac0fcb32f55a6
    
* When we receive a shuffle reply, make sure to actually use the new
    nodes to fill our active view (if needed)
* Include our own node in shuffle replies, as specified by the paper

**change(hyparview): Send a ShuffleReply before disconnecting (#59)**
fd379fc5f32ee52c2c7aad03c03c373c2ac69816
    
Before disconnecting from a peer, we send a ShuffleReply message to
inform the peer about more nodes we know about. This will increase the
chances that the peer still has enough nodes to keep active.
    
**fix(plumtree): Ensure eager relation is symmetrical**
0abface77c81dfde91c9f37da1f00bfee36f86d7
    
Small fix to plumtree implementation: Make sure that when we send out a
Graft message, we also mark the peer eager in our state. Same the other
way round: When we send a Prune message, mark the peer as lazy in our
state.
    
**fix(hyparview): Don't emit PeerData event for empty PeerData**
c345f0a0a6a099643f13a7a6743b308548a1c40e
    
Minor fix to hyparview: If PeerData is empty, there's no need to emit a
PeerData event.

**fix(plumtree): Clear graft timer to allow retry on new ihaves**
b65cdcea36c8b30ac3ab6443645c6e69795f6ebf
    
Make sure to clear the scheduled state of a graft timer after it
expired, so that it can be rescheduled if the need arises.
    
**refactor(hyparview): Remove obsolete parameter in hyparview**
d954aa62272d7f781ce762b42b06d2521e7d1b30

Removes an unused `now` parameter in the functions of the hyparview
state.


## Breaking Changes

While this is not a wire- or API-breaking change, this changes the
behavior as to which messages are sent out when. While I think that
nodes before and after this change will work well together, we did not
verify or test this yet.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
