### PR TITLE
refactor: Update metrics to latest iroh-metrics PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,7 +1713,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh"
 version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh?branch=Frando/metrics2#3d22b7e9dca1467a9bf26689ca28ffe1d1393af0"
+source = "git+https://github.com/n0-computer/iroh?branch=Frando/metrics#e44aa54843f2228a533846eb56956bc16ec639d9"
 dependencies = [
  "aead",
  "anyhow",
@@ -1772,7 +1772,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh?branch=Frando/metrics2#3d22b7e9dca1467a9bf26689ca28ffe1d1393af0"
+source = "git+https://github.com/n0-computer/iroh?branch=Frando/metrics#e44aa54843f2228a533846eb56956bc16ec639d9"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.33.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=main#a589407937d851c5e9424431b86eee24e3dddd93"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -1849,7 +1849,7 @@ dependencies = [
  "itoa",
  "reqwest",
  "serde",
- "thiserror 2.0.11",
+ "snafu",
  "tokio",
  "tracing",
 ]
@@ -1857,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=main#a589407937d851c5e9424431b86eee24e3dddd93"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh?branch=Frando/metrics2#3d22b7e9dca1467a9bf26689ca28ffe1d1393af0"
+source = "git+https://github.com/n0-computer/iroh?branch=Frando/metrics#e44aa54843f2228a533846eb56956bc16ec639d9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2355,7 +2355,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#647b31b2c4468b7fe8651f8a31d5fea5411ee549"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ff9840322c1c57dc87010f2909f174c5bb8944b3"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2788,7 +2788,7 @@ checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#647b31b2c4468b7fe8651f8a31d5fea5411ee549"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ff9840322c1c57dc87010f2909f174c5bb8944b3"
 dependencies = [
  "base64",
  "bytes",
@@ -2798,7 +2798,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2)",
+ "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics)",
  "num_enum",
  "rand 0.8.5",
  "serde",
@@ -3699,6 +3699,27 @@ name = "smallvec"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+
+[[package]]
+name = "snafu"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,12 +829,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
-
-[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,7 +1713,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh"
 version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh?branch=Frando/metrics#d18257e963e4df60bc74e041298568bb8be6846c"
+source = "git+https://github.com/n0-computer/iroh?branch=Frando/metrics2#3d22b7e9dca1467a9bf26689ca28ffe1d1393af0"
 dependencies = [
  "aead",
  "anyhow",
@@ -1778,7 +1772,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh?branch=Frando/metrics#d18257e963e4df60bc74e041298568bb8be6846c"
+source = "git+https://github.com/n0-computer/iroh?branch=Frando/metrics2#3d22b7e9dca1467a9bf26689ca28ffe1d1393af0"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -1846,14 +1840,13 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d64b607e49f67fa42b3e780109cad0fa1fdb476b4a78d4cf8443499bbc1ad0a"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
 dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
  "iroh-metrics-derive",
- "prometheus-client",
+ "itoa",
  "reqwest",
  "serde",
  "thiserror 2.0.11",
@@ -1864,8 +1857,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa484b5f192006b1cc39261712d65baf87342fc72a4acc1560355d1dc410d9"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando/derive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1931,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh?branch=Frando/metrics#d18257e963e4df60bc74e041298568bb8be6846c"
+source = "git+https://github.com/n0-computer/iroh?branch=Frando/metrics2#3d22b7e9dca1467a9bf26689ca28ffe1d1393af0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2363,7 +2355,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.4.0"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ef897c745d78dbd19429bdf6131f91c9563c2c1a"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#647b31b2c4468b7fe8651f8a31d5fea5411ee549"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2796,7 +2788,7 @@ checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 [[package]]
 name = "portmapper"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics#ef897c745d78dbd19429bdf6131f91c9563c2c1a"
+source = "git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2#647b31b2c4468b7fe8651f8a31d5fea5411ee549"
 dependencies = [
  "base64",
  "bytes",
@@ -2806,7 +2798,7 @@ dependencies = [
  "igd-next",
  "iroh-metrics",
  "libc",
- "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics)",
+ "netwatch 0.4.0 (git+https://github.com/n0-computer/net-tools?branch=Frando/metrics2)",
  "num_enum",
  "rand 0.8.5",
  "serde",
@@ -2909,29 +2901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,4 +115,5 @@ all-features = true
 rustdoc-args = ["--cfg", "iroh_docsrs"]
 
 [patch.crates-io]
-iroh = { git = "https://github.com/n0-computer/iroh", branch = "Frando/metrics" }
+iroh = { git = "https://github.com/n0-computer/iroh", branch = "Frando/metrics2" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,5 +115,5 @@ all-features = true
 rustdoc-args = ["--cfg", "iroh_docsrs"]
 
 [patch.crates-io]
-iroh = { git = "https://github.com/n0-computer/iroh", branch = "Frando/metrics2" }
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset" }
+iroh = { git = "https://github.com/n0-computer/iroh", branch = "Frando/metrics" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main" }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,7 +3,7 @@
 use iroh_metrics::{Counter, MetricsGroup};
 
 /// Enum of metrics for the module
-#[derive(Debug, Clone, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup)]
 #[metrics(name = "gossip")]
 pub struct Metrics {
     /// Number of control messages sent

--- a/src/net.rs
+++ b/src/net.rs
@@ -320,7 +320,7 @@ impl Gossip {
     }
 
     /// Returns the metrics tracked for this gossip instance.
-    pub fn metrics(&self) -> &Metrics {
+    pub fn metrics(&self) -> &Arc<Metrics> {
         &self.inner.metrics
     }
 }


### PR DESCRIPTION
## Description

Updates #58  for the latest iroh-metrics PR (see link below).

Depends on #58
Depends on  https://github.com/n0-computer/iroh/pull/3278 and 
Depends on https://github.com/n0-computer/iroh-metrics/pull/22
Depends on https://github.com/n0-computer/iroh-metrics/pull/23

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
