### PR TITLE
fix: respect max message size when constructing IHave messages

### DIFF
--- a/src/proto.rs
+++ b/src/proto.rs
@@ -64,6 +64,13 @@ pub use plumtree::{Config as PlumtreeConfig, DeliveryScope, Scope};
 pub use state::{InEvent, Message, OutEvent, State, Timer, TopicId};
 pub use topic::{Command, Config, Event, IO};
 
+/// The default maximum size in bytes for a gossip message.
+/// This is a sane but arbitrary default and can be changed in the [`Config`].
+pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 4096;
+
+/// The minimum allowed value for [`Config::max_message_size`].
+pub const MIN_MAX_MESSAGE_SIZE: usize = 512;
+
 /// The identifier for a peer.
 ///
 /// The protocol implementation is generic over this trait. When implementing the protocol,

--- a/src/proto/plumtree.rs
+++ b/src/proto/plumtree.rs
@@ -446,7 +446,7 @@ impl<PI: PeerIdentity> State<PI> {
             // Space for length prefix
             - 2;
         let chunk_len = chunk_size / IHave::postcard_encoded_size();
-        while let Some((peer, list)) = self.lazy_push_queue.pop_first() {
+        for (peer, list) in self.lazy_push_queue.drain() {
             for chunk in list.chunks(chunk_len) {
                 io.push(OutEvent::SendMessage(peer, Message::IHave(chunk.to_vec())));
             }

--- a/src/proto/state.rs
+++ b/src/proto/state.rs
@@ -13,7 +13,7 @@ use crate::{
     proto::{
         topic::{self, Command},
         util::idbytes_impls,
-        Config, PeerData, PeerIdentity,
+        Config, PeerData, PeerIdentity, MIN_MAX_MESSAGE_SIZE,
     },
 };
 
@@ -161,7 +161,16 @@ impl<PI: PeerIdentity, R: Rng + Clone> State<PI, R> {
     /// (which can be updated over time).
     /// For the protocol to perform as recommended in the papers, the [`Config`] should be
     /// identical for all nodes in the network.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if [`Config::max_message_size`] is below [`MIN_MAX_MESSAGE_SIZE`].
     pub fn new(me: PI, me_data: PeerData, config: Config, rng: R) -> Self {
+        assert!(
+            config.max_message_size >= MIN_MAX_MESSAGE_SIZE,
+            "max_message_size must be at least {}",
+            MIN_MAX_MESSAGE_SIZE
+        );
         Self {
             me,
             me_data,

--- a/src/proto/topic.rs
+++ b/src/proto/topic.rs
@@ -9,16 +9,14 @@ use rand::Rng;
 use rand_core::SeedableRng;
 use serde::{Deserialize, Serialize};
 
+use crate::proto::MIN_MAX_MESSAGE_SIZE;
+
 use super::{
     hyparview::{self, InEvent as SwarmIn},
     plumtree::{self, GossipEvent, InEvent as GossipIn, Scope},
     state::MessageKind,
-    PeerData, PeerIdentity,
+    PeerData, PeerIdentity, DEFAULT_MAX_MESSAGE_SIZE,
 };
-
-/// The default maximum size in bytes for a gossip message.
-/// This is a sane but arbitrary default and can be changed in the [`Config`].
-pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 4096;
 
 /// Input event to the topic state handler.
 #[derive(Clone, Debug)]
@@ -212,6 +210,10 @@ pub struct State<PI, R> {
 
 impl<PI: PeerIdentity> State<PI, rand::rngs::StdRng> {
     /// Initialize the local state with the default random number generator.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if [`Config::max_message_size`] is below [`MIN_MAX_MESSAGE_SIZE`].
     pub fn new(me: PI, me_data: Option<PeerData>, config: Config) -> Self {
         Self::with_rng(me, me_data, config, rand::rngs::StdRng::from_entropy())
     }
@@ -226,7 +228,16 @@ impl<PI, R> State<PI, R> {
 
 impl<PI: PeerIdentity, R: Rng> State<PI, R> {
     /// Initialize the local state with a custom random number generator.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if [`Config::max_message_size`] is below [`MIN_MAX_MESSAGE_SIZE`].
     pub fn with_rng(me: PI, me_data: Option<PeerData>, config: Config, rng: R) -> Self {
+        assert!(
+            config.max_message_size >= MIN_MAX_MESSAGE_SIZE,
+            "max_message_size must be at least {}",
+            MIN_MAX_MESSAGE_SIZE
+        );
         let max_payload_size =
             config.max_message_size - super::Message::<PI>::postcard_header_size();
         Self {

--- a/src/proto/topic.rs
+++ b/src/proto/topic.rs
@@ -227,9 +227,11 @@ impl<PI, R> State<PI, R> {
 impl<PI: PeerIdentity, R: Rng> State<PI, R> {
     /// Initialize the local state with a custom random number generator.
     pub fn with_rng(me: PI, me_data: Option<PeerData>, config: Config, rng: R) -> Self {
+        let max_payload_size =
+            config.max_message_size - super::Message::<PI>::postcard_header_size();
         Self {
             swarm: hyparview::State::new(me, me_data, config.membership, rng),
-            gossip: plumtree::State::new(me, config.broadcast),
+            gossip: plumtree::State::new(me, config.broadcast, max_payload_size),
             me,
             outbox: VecDeque::new(),
             stats: Stats::default(),

--- a/src/proto/topic.rs
+++ b/src/proto/topic.rs
@@ -9,14 +9,13 @@ use rand::Rng;
 use rand_core::SeedableRng;
 use serde::{Deserialize, Serialize};
 
-use crate::proto::MIN_MAX_MESSAGE_SIZE;
-
 use super::{
     hyparview::{self, InEvent as SwarmIn},
     plumtree::{self, GossipEvent, InEvent as GossipIn, Scope},
     state::MessageKind,
     PeerData, PeerIdentity, DEFAULT_MAX_MESSAGE_SIZE,
 };
+use crate::proto::MIN_MAX_MESSAGE_SIZE;
 
 /// Input event to the topic state handler.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Description

Previously, on large swarms with many messages published the batched list of `IHave` lazy pushes sent to a peer could become larger than the configured max_message_size. If that happened, things would break in the send loop in the `net` module, because that is where the max_message_size is checked.

Fixing this is complicated by the fact that the `proto` module is, so far, encoding-agnostic. The solution implemented here is maybe not the cleanest, but it works: We assume `postcard` encoding for calculating how many `IHave`s we can fit into a message. I did not yet come up with a clean and not too complex solution for handling this differently, also I don't see a reason for not encoding in postcard. We might want to document this constraint though, should anyone use the `proto`  module on their own.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
