### PR TITLE
feat(net): Add `shutdown` function to gracefully shutdown `Gossip`

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -27,7 +27,7 @@ use n0_future::{
 use rand::rngs::StdRng;
 use rand_core::SeedableRng;
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, error_span, trace, warn, Instrument};
 
@@ -160,6 +160,15 @@ impl ProtocolHandler for Gossip {
         Box::pin(async move {
             inner.handle_connection(conn).await?;
             Ok(())
+        })
+    }
+
+    fn shutdown(&self) -> BoxFuture<()> {
+        let this = self.clone();
+        Box::pin(async move {
+            if let Err(err) = this.shutdown().await {
+                warn!("error while shutting down gossip: {err:#}");
+            }
         })
     }
 }
@@ -316,6 +325,17 @@ impl Gossip {
     ) -> EventStream {
         self.inner.subscribe_with_stream(topic_id, options, updates)
     }
+
+    /// Shutdown the gossip instance.
+    ///
+    /// This leaves all topics, sending `Disconnect` messages to peers, and then
+    /// stops the gossip actor loop and drops all state and connections.
+    pub async fn shutdown(&self) -> anyhow::Result<()> {
+        let (reply, reply_rx) = oneshot::channel();
+        self.inner.send(ToActor::Shutdown { reply }).await?;
+        reply_rx.await?;
+        Ok(())
+    }
 }
 
 impl Inner {
@@ -450,6 +470,9 @@ enum ToActor {
         topic: TopicId,
         receiver_id: ReceiverId,
     },
+    Shutdown {
+        reply: oneshot::Sender<()>,
+    },
 }
 
 /// Actor that sends and handles messages between the connection and main state loops
@@ -580,7 +603,18 @@ impl Actor {
                 trace!(?i, "tick: to_actor_rx");
                 inc!(Metrics, actor_tick_rx);
                 match msg {
-                    Some(msg) => self.handle_to_actor_msg(msg, Instant::now()).await?,
+                    Some(msg) => {
+                        if let ToActor::Shutdown { reply } = msg {
+                            debug!("received shutdown message, quit all topics");
+                            self.quit_queue.extend(self.topics.keys().copied());
+                            self.process_quit_queue().await.ok();
+                            debug!("all topics quit, stop gossip actor");
+                            reply.send(()).ok();
+                            return Ok(None)
+                        } else {
+                            self.handle_to_actor_msg(msg, Instant::now()).await?;
+                        }
+                    }
                     None => {
                         debug!("all gossip handles dropped, stop gossip actor");
                         return Ok(None)
@@ -808,6 +842,7 @@ impl Actor {
             ToActor::ReceiverGone { topic, receiver_id } => {
                 self.handle_receiver_gone(topic, receiver_id).await?;
             }
+            ToActor::Shutdown { .. } => unreachable!("handled in main loop"),
         }
         Ok(())
     }


### PR DESCRIPTION
## Description

This adds `Gossip::shutdown`, which leaves all topics, sending `Disconnect` messages to peers as needed, and then stop the Gossip actor.

It is called and awaited from `ProtocolHandler::shutdown`. By doing this, we make sure that the loop terminates together with the endpoint, and doesn't fail with errors afterwards.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
