### PR TITLE
chore: update to `iroh` v0.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,8 +1718,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iroh"
-version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#146f423a6805ab0147703832ad98ee6c52797174"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ca758f4ce39ae3f07de922be6c73de6a48a07f39554e78b5745585652ce38f5"
 dependencies = [
  "aead",
  "anyhow",
@@ -1780,8 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#146f423a6805ab0147703832ad98ee6c52797174"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91ac4aaab68153d726c4e6b39c30f9f9253743f0e25664e52f4caeb46f48d11"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -1933,8 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#146f423a6805ab0147703832ad98ee6c52797174"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c63f122cdfaa4b4e0e7d6d3921d2b878f42a0c6d3ee5a29456dc3f5ab5ec931f"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2906,8 +2909,9 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.19.0"
-source = "git+https://github.com/n0-computer/quic-rpc.git?branch=patch-iroh-main#7211bf5ccadc2c80fc107e1b6ff093ac27eda85a"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18bad98bd048264ceb1361ff9d77a031535d8c1e3fe8f12c6966ec825bf68eb7"
 dependencies = [
  "anyhow",
  "document-features",
@@ -2927,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc-derive"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a99f334af6f23b3de91f6df9ac17237e8b533b676f596c69dcb3b58c3cf8dea"
+checksum = "abf13f1bced5f2f2642d9d89a29d75f2d81ab34c4acfcb434c209d6094b9b2b7"
 dependencies = [
  "proc-macro2",
  "quic-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.19.0"
-source = "git+https://github.com/n0-computer/quic-rpc.git?branch=main#3e2b3ee982c934ecb3527bb163be4a8570f62483"
+source = "git+https://github.com/n0-computer/quic-rpc.git?branch=patch-iroh-main#7211bf5ccadc2c80fc107e1b6ff093ac27eda85a"
 dependencies = [
  "anyhow",
  "document-features",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,7 +1719,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh"
 version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#a62a2bd25f5280a8d1512bcd261e666731de5d95"
+source = "git+https://github.com/n0-computer/iroh?branch=main#146f423a6805ab0147703832ad98ee6c52797174"
 dependencies = [
  "aead",
  "anyhow",
@@ -1781,7 +1781,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#a62a2bd25f5280a8d1512bcd261e666731de5d95"
+source = "git+https://github.com/n0-computer/iroh?branch=main#146f423a6805ab0147703832ad98ee6c52797174"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -1934,7 +1934,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#a62a2bd25f5280a8d1512bcd261e666731de5d95"
+source = "git+https://github.com/n0-computer/iroh?branch=main#146f423a6805ab0147703832ad98ee6c52797174"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2907,8 +2907,7 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89561e5343bcad1c9f84321d9d9bd1619128ad44293faad55a0001b0e52d312b"
+source = "git+https://github.com/n0-computer/quic-rpc.git?branch=main#3e2b3ee982c934ecb3527bb163be4a8570f62483"
 dependencies = [
  "anyhow",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,4 +118,4 @@ rustdoc-args = ["--cfg", "iroh_docsrs"]
 
 [patch.crates-io]
 iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "main" }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "patch-iroh-main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,3 +115,7 @@ required-features = ["examples"]
 all-features = true
 rustdoc-args = ["--cfg", "iroh_docsrs"]
 
+
+[patch.crates-io]
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ anyhow = { version = "1", optional = true }
 futures-lite = { version = "2.3", optional = true }
 futures-concurrency = { version = "7.6.1", optional = true }
 futures-util = { version = "0.3.30", optional = true }
-iroh = { git = "https://github.com/n0-computer/iroh", branch = "main", default-features = false, optional = true }
+iroh = { version = "0.35", default-features = false, optional = true }
 tokio = { version = "1", optional = true, features = ["io-util", "sync"] }
 tokio-util = { version = "0.7.12", optional = true, features = ["codec"] }
 tracing = "0.1"
@@ -61,15 +61,15 @@ thiserror = { version = "2.0", optional = true }
 
 # rpc dependencies (optional)
 nested_enum_utils = { version = "0.1.0", optional = true }
-quic-rpc = { version = "0.19", optional = true }
-quic-rpc-derive = { version = "0.19", optional = true }
+quic-rpc = { version = "0.20", optional = true }
+quic-rpc-derive = { version = "0.20", optional = true }
 strum = { version = "0.26", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "sync", "rt", "macros", "net", "fs"] }
 clap = { version = "4", features = ["derive"] }
-iroh = { git = "https://github.com/n0-computer/iroh", branch = "main", default-features = false, features = ["metrics", "test-utils"] }
+iroh = { version = "0.35", default-features = false, features = ["metrics", "test-utils"] }
 rand_chacha = "0.3.1"
 testresult = "0.4.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -114,8 +114,3 @@ required-features = ["examples"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "iroh_docsrs"]
-
-
-[patch.crates-io]
-iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "patch-iroh-main" }

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ async fn main() -> anyhow::Result<()> {
     // setup router
     let router = Router::builder(endpoint.clone())
         .accept(ALPN, gossip.clone())
-        .spawn()
-        .await?;
+        .spawn();
     // do fun stuff with the gossip protocol
     router.shutdown().await?;
     Ok(())

--- a/deny.toml
+++ b/deny.toml
@@ -1,43 +1,45 @@
-[bans]
-multiple-versions = "allow"
-deny = [
-     "aws-lc",
-     "aws-lc-rs",
-     "aws-lc-sys",
-     "native-tls",
-     "openssl",
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0384",
+    "RUSTSEC-2024-0436",
 ]
+
+[bans]
+deny = [
+    "aws-lc",
+    "aws-lc-rs",
+    "aws-lc-sys",
+    "native-tls",
+    "openssl",
+]
+multiple-versions = "allow"
 
 [licenses]
 allow = [
-      "Apache-2.0",
-      "Apache-2.0 WITH LLVM-exception",
-      "BSD-2-Clause",
-      "BSD-3-Clause",
-      "BSL-1.0", # BOSL license
-      "CDLA-Permissive-2.0", # https://cdla.dev/permissive-2-0/
-      "ISC",
-      "MIT",
-      "Zlib",
-      "Unicode-3.0",
-      "MPL-2.0", # https://fossa.com/blog/open-source-software-licenses-101-mozilla-public-license-2-0/
-      "Unlicense", # https://unlicense.org/
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "Zlib",
+    "Unicode-3.0",
+    "MPL-2.0",
+    "Unlicense",
 ]
 
 [[licenses.clarify]]
-name = "ring"
 expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-      { path = "LICENSE", hash = 0xbd0eed23 },
-]
+name = "ring"
 
-[advisories]
-ignore = [
-      "RUSTSEC-2024-0384", # unmaintained, no upgrade available
-      "RUSTSEC-2024-0436", # paste,
-]
+[[licenses.clarify.license-files]]
+hash = 3171872035
+path = "LICENSE"
 
 [sources]
 allow-git = [
+    "https://github.com/n0-computer/quic-rpc.git",
     "https://github.com/n0-computer/iroh.git",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -39,7 +39,4 @@ hash = 3171872035
 path = "LICENSE"
 
 [sources]
-allow-git = [
-    "https://github.com/n0-computer/quic-rpc.git",
-    "https://github.com/n0-computer/iroh.git",
-]
+allow-git = []

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use clap::Parser;
 use ed25519_dalek::Signature;
 use futures_lite::StreamExt;
-use iroh::{Endpoint, NodeAddr, PublicKey, RelayMap, RelayMode, RelayUrl, SecretKey};
+use iroh::{Endpoint, NodeAddr, PublicKey, RelayMode, RelayUrl, SecretKey};
 use iroh_gossip::{
     net::{Event, Gossip, GossipEvent, GossipReceiver, GOSSIP_ALPN},
     proto::TopicId,
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
     // configure our relay map
     let relay_mode = match (args.no_relay, args.relay) {
         (false, None) => RelayMode::Default,
-        (false, Some(url)) => RelayMode::Custom(RelayMap::from_url(url)),
+        (false, Some(url)) => RelayMode::Custom(url.into()),
         (true, None) => RelayMode::Disabled,
         (true, Some(_)) => bail!("You cannot set --no-relay and --relay at the same time"),
     };
@@ -124,8 +124,7 @@ async fn main() -> Result<()> {
     // setup router
     let router = iroh::protocol::Router::builder(endpoint.clone())
         .accept(GOSSIP_ALPN, gossip.clone())
-        .spawn()
-        .await?;
+        .spawn();
 
     // join the gossip topic by connecting to known peers, if any
     let peer_ids = peers.iter().map(|p| p.node_id).collect();

--- a/examples/setup.rs
+++ b/examples/setup.rs
@@ -13,8 +13,7 @@ async fn main() -> anyhow::Result<()> {
     // setup router
     let router = Router::builder(endpoint.clone())
         .accept(ALPN, gossip.clone())
-        .spawn()
-        .await?;
+        .spawn();
     // do fun stuff with the gossip protocol
     router.shutdown().await?;
     Ok(())

--- a/src/net.rs
+++ b/src/net.rs
@@ -1875,8 +1875,7 @@ mod test {
             let gossip = Gossip::builder().spawn(ep.clone()).await?;
             let router = Router::builder(ep.clone())
                 .accept(GOSSIP_ALPN, gossip.clone())
-                .spawn()
-                .await?;
+                .spawn();
             Ok((router, gossip))
         }
 


### PR DESCRIPTION
## Description

Update to the latest `iroh`, `quic-rpc`, and `quic-rpc-derive` release.