### PR TITLE
deny warnings for docs in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -239,7 +239,7 @@ jobs:
     - name: Docs
       run: cargo doc --workspace --all-features --no-deps --document-private-items
       env:
-        RUSTDOCFLAGS: --cfg docsrs
+        RUSTDOCFLAGS: --cfg iroh_docsrs -Dwarnings
 
   clippy_check:
     timeout-minutes: 30

--- a/src/proto/plumtree.rs
+++ b/src/proto/plumtree.rs
@@ -244,7 +244,7 @@ pub struct Graft {
 #[serde(default)]
 pub struct Config {
     /// When receiving an `IHave` message, this timeout is registered. If the message for the
-    /// `IHave` was not received once the timeout is expired, a `Graft` message is sent to the
+    /// [`IHave`] was not received once the timeout is expired, a `Graft` message is sent to the
     /// peer that sent us the `IHave` to request the message payload.
     ///
     /// The plumtree paper notes:

--- a/src/proto/plumtree.rs
+++ b/src/proto/plumtree.rs
@@ -243,28 +243,28 @@ pub struct Graft {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
-    /// When receiving an [`IHave`] message, this timeout is registered. If the message for the
-    /// [`IHave`] was not received once the timeout is expired, a [`Graft`] message is sent to the
-    /// peer that sent us the [`IHave`] to request the message payload.
+    /// When receiving an `IHave` message, this timeout is registered. If the message for the
+    /// `IHave` was not received once the timeout is expired, a `Graft` message is sent to the
+    /// peer that sent us the `IHave` to request the message payload.
     ///
     /// The plumtree paper notes:
     /// > The timeout value is a protocol parameter that should be configured considering the
     /// > diameter of the overlay and a target maximum recovery latency, defined by the application
     /// > requirements. (p.8)
     pub graft_timeout_1: Duration,
-    /// This timeout is registered when sending a [`Graft`] message. If a reply has not been
-    /// received once the timeout expires, we send another [`Graft`] message to the next peer that
-    /// sent us an [`IHave`] for this message.
+    /// This timeout is registered when sending a `Graft` message. If a reply has not been
+    /// received once the timeout expires, we send another `Graft` message to the next peer that
+    /// sent us an `IHave` for this message.
     ///
     /// The plumtree paper notes:
     /// > This second timeout value should be smaller that the first, in the order of an average
     /// > round trip time to a neighbor.
     pub graft_timeout_2: Duration,
-    /// Timeout after which [`IHave`] messages are pushed to peers.
+    /// Timeout after which `IHave` messages are pushed to peers.
     pub dispatch_timeout: Duration,
     /// The protocol performs a tree optimization, which promotes lazy peers to eager peers if the
-    /// [`Message::IHave`] messages received from them have a lower number of hops from the
-    /// message's origin as the [`InEvent::Broadcast`] messages received from our eager peers. This
+    /// `Message::IHave` messages received from them have a lower number of hops from the
+    /// message's origin as the `InEvent::Broadcast` messages received from our eager peers. This
     /// parameter is the number of hops that the lazy peers must be closer to the origin than our
     /// eager peers to be promoted to become an eager peer.
     pub optimization_threshold: Round,
@@ -278,7 +278,7 @@ pub struct Config {
     /// Should be at least around several round trip times to peers.
     pub message_cache_retention: Duration,
 
-    /// Duration for which to keep the [`MessageId`]s for received messages.
+    /// Duration for which to keep the `MessageId`s for received messages.
     ///
     /// Should be at least as long as [`Self::message_cache_retention`], usually will be longer to
     /// not accidentally receive messages multiple times.


### PR DESCRIPTION
## Description

Fixes docs and ensures the docs test in CI catches them

## Breaking Changes

none

## Notes & open questions

Removing the links is perhaps not the best solution, issue tbd

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
