### PR TITLE
fix: make GossipSender `Clone` and GossipReceiver `Sync`

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -145,7 +145,7 @@ async fn main() -> Result<()> {
             endpoint.add_node_addr(peer)?;
         }
     };
-    let (mut sender, receiver) = gossip.subscribe_and_join(topic, peer_ids).await?.split();
+    let (sender, receiver) = gossip.subscribe_and_join(topic, peer_ids).await?.split();
     println!("> connected!");
 
     // broadcast our name, if set

--- a/src/api.rs
+++ b/src/api.rs
@@ -183,7 +183,7 @@ impl GossipApi {
 }
 
 /// Sender for a gossip topic.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GossipSender(mpsc::Sender<Command>);
 
 impl GossipSender {
@@ -192,24 +192,24 @@ impl GossipSender {
     }
 
     /// Broadcasts a message to all nodes.
-    pub async fn broadcast(&mut self, message: Bytes) -> Result<(), ApiError> {
+    pub async fn broadcast(&self, message: Bytes) -> Result<(), ApiError> {
         self.send(Command::Broadcast(message)).await?;
         Ok(())
     }
 
     /// Broadcasts a message to our direct neighbors.
-    pub async fn broadcast_neighbors(&mut self, message: Bytes) -> Result<(), ApiError> {
+    pub async fn broadcast_neighbors(&self, message: Bytes) -> Result<(), ApiError> {
         self.send(Command::BroadcastNeighbors(message)).await?;
         Ok(())
     }
 
     /// Joins a set of peers.
-    pub async fn join_peers(&mut self, peers: Vec<NodeId>) -> Result<(), ApiError> {
+    pub async fn join_peers(&self, peers: Vec<NodeId>) -> Result<(), ApiError> {
         self.send(Command::JoinPeers(peers)).await?;
         Ok(())
     }
 
-    async fn send(&mut self, command: Command) -> Result<(), irpc::channel::SendError> {
+    async fn send(&self, command: Command) -> Result<(), irpc::channel::SendError> {
         self.0.send(command).await?;
         Ok(())
     }
@@ -382,7 +382,7 @@ pub struct Message {
 }
 
 /// Command for a gossip topic.
-#[derive(Serialize, Deserialize, derive_more::Debug)]
+#[derive(Serialize, Deserialize, derive_more::Debug, Clone)]
 pub enum Command {
     /// Broadcasts a message to all nodes in the swarm.
     Broadcast(#[debug("Bytes({})", _0.len())] Bytes),

--- a/src/net.rs
+++ b/src/net.rs
@@ -1273,7 +1273,7 @@ pub(crate) mod test {
         .await
         .unwrap();
 
-        let (mut sink1, _stream1) = sub1.split();
+        let (sink1, _stream1) = sub1.split();
 
         let len = 2;
 


### PR DESCRIPTION
## Description

We have two oversights in the 0.90 release:

* `GossipSender` can be `Clone` and take `&self`, not `&mut self` in its methods. We changed irpc to enable that, but did not actually change the implementation in iroh-gossip after #67 was merged (which made `GossipSender` !Clone).
* `GossipReceiver` and `GossipTopic` do not implement `Sync` at the moment, which can be troublesome sometimes when `Gossip`  is embedded in some struct that needs `Sync` bounds to be met. And there's no actual reason for this: The pinned stream that causes `!Sync` atm actually is `Sync`, we just didn't specify the bound.

## Breaking Changes

I don't think this change can break any userspace code. There'll be warning that `GossipSender` doesn't need to be `mut`, but rust auto-derefs from `&mut GossipSender` to `&GossipSender` automatically.

Changed:

* The methods on `GossipSender`  now take `&self` instead of `&mut self` and implements `Clone`
* `GossipReceiver` and `GossipTopic` now implement `Sync`

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
