### PR TITLE
chore: upgrade `iroh`, `iroh-base`, `irpc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,9 +1805,8 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.91.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef05c956df0788a649d65c33fdbbb8fc4442d7716af3d67a1bd6d00a9ee56ead"
+version = "0.91.2"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#4583b1280b8f5ab9d264940102382956ddbbb1a8"
 dependencies = [
  "aead",
  "axum",
@@ -1867,9 +1866,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "0.91.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68b5c5e190d8965699b2fd583f301a7e6094a0b89bb4d6c5baa94761fd1b7a3"
+version = "0.91.2"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#4583b1280b8f5ab9d264940102382956ddbbb1a8"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -2014,9 +2012,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "0.91.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49596b5079817d0904fe4985307f532a4e23a33eb494bd680baaf2743f0c456b"
+version = "0.91.2"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#4583b1280b8f5ab9d264940102382956ddbbb1a8"
 dependencies = [
  "ahash",
  "blake3",
@@ -2081,8 +2078,7 @@ dependencies = [
 [[package]]
 name = "irpc"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f8f1d0987ea9da3d74698f921d0a817a214c83b2635a33ed4bc3efa4de1acd"
+source = "git+https://github.com/n0-computer/irpc.git?branch=iroh-0-92#deeccb327c23760e0b3ab6c9df053f04d0b70dd6"
 dependencies = [
  "anyhow",
  "futures-buffered",
@@ -2104,8 +2100,7 @@ dependencies = [
 [[package]]
 name = "irpc-derive"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0b26b834d401a046dd9d47bc236517c746eddbb5d25ff3e1a6075bfa4eebdb"
+source = "git+https://github.com/n0-computer/irpc.git?branch=iroh-0-92#deeccb327c23760e0b3ab6c9df053f04d0b70dd6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "n0-snafu"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fed465ff57041f29db78a9adc8864296ef93c6c16029f9e192dc303404ebd0"
+checksum = "1815107e577a95bfccedb4cfabc73d709c0db6d12de3f14e0f284a8c5036dc4f"
 dependencies = [
  "anyhow",
  "btparse",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,8 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.91.2"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#4583b1280b8f5ab9d264940102382956ddbbb1a8"
+version = "0.92.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ad6b793a5851b9e5435ad36fea63df485f8fd4520a58117e7dc3326a69c15"
 dependencies = [
  "aead",
  "axum",
@@ -1835,7 +1836,7 @@ dependencies = [
  "n0-snafu",
  "n0-watcher",
  "nested_enum_utils",
- "netdev",
+ "netdev 0.36.0",
  "netwatch",
  "pin-project",
  "pkarr",
@@ -1866,8 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "0.91.2"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#4583b1280b8f5ab9d264940102382956ddbbb1a8"
+version = "0.92.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ae51a14c9255a735b1db2d8cf29b875b971e96a5b23e4d0d1ee7d85bf32132"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -2012,8 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "0.91.2"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#4583b1280b8f5ab9d264940102382956ddbbb1a8"
+version = "0.92.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "315cb02e660de0de339303296df9a29b27550180bb3979d0753a267649b34a7f"
 dependencies = [
  "ahash",
  "blake3",
@@ -2077,8 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "irpc"
-version = "0.7.0"
-source = "git+https://github.com/n0-computer/irpc.git?branch=iroh-0-92#deeccb327c23760e0b3ab6c9df053f04d0b70dd6"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092c0b20697bbc7de4839eebcb49be975cc09221021626d301eea55fc10bfeb7"
 dependencies = [
  "anyhow",
  "futures-buffered",
@@ -2099,8 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.5.0"
-source = "git+https://github.com/n0-computer/irpc.git?branch=iroh-0-92#deeccb327c23760e0b3ab6c9df053f04d0b70dd6"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209d38d83c0f7043916e90de2d3a8d01035db3a2f49ea7d5fb41b8f43e889924"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2227,11 +2232,11 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2378,6 +2383,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "netdev"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daa1e3eaf125c54c21e6221df12dd2a0a682784a068782dd564c836c0f281b6d"
+dependencies = [
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-route 0.22.0",
+ "netlink-sys",
+ "once_cell",
+ "system-configuration",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901dbb408894af3df3fc51420ba0c6faf3a7d896077b797c39b7001e2f787bd"
+checksum = "8a63d76f52f3f15ebde3ca751a2ab73a33ae156662bc04383bac8e824f84e9bb"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2473,7 +2495,7 @@ dependencies = [
  "n0-future",
  "n0-watcher",
  "nested_enum_utils",
- "netdev",
+ "netdev 0.37.3",
  "netlink-packet-core",
  "netlink-packet-route 0.24.0",
  "netlink-proto",
@@ -2537,12 +2559,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2646,12 +2667,6 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -2901,9 +2916,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portmapper"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f1975debe62a70557e42b9ff9466e4890cf9d3d156d296408a711f1c5f642b"
+checksum = "a9f99e8cd25cd8ee09fc7da59357fd433c0a19272956ebb4ad7443b21842988d"
 dependencies = [
  "base64",
  "bytes",
@@ -3257,17 +3272,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3278,7 +3284,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3286,12 +3292,6 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3800,9 +3800,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -4454,14 +4454,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ irpc = { version = "0.7.0", optional = true, default-features = false, features 
     "stream",
     "spans",
 ] }
-n0-snafu = { version = "0.2.1", optional = true }
+n0-snafu = { version = "0.2.2", optional = true }
 nested_enum_utils = { version = "0.2.2", optional = true }
 snafu = { version = "0.8.5", features = ["rust_1_81"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ ed25519-dalek = { version = "2.0.0", features = ["serde", "rand_core"] }
 hex = "0.4.3"
 indexmap = "2.0"
 iroh-metrics = { version = "0.35", default-features = false }
-iroh-base = { version = "0.91", default-features = false, features = ["key"] }
+iroh-base = { version = "0.92", default-features = false, features = ["key"] }
 n0-future = "0.1.2"
 postcard = { version = "1", default-features = false, features = [
     "alloc",
@@ -63,11 +63,11 @@ serde = { version = "1.0.164", features = ["derive"] }
 futures-lite = { version = "2.3", optional = true }
 futures-concurrency = { version = "7.6.1", optional = true }
 futures-util = { version = "0.3.30", optional = true }
-iroh = { version = "0.91", default-features = false, optional = true }
+iroh = { version = "0.92", default-features = false, optional = true }
 tokio = { version = "1", optional = true, features = ["io-util", "sync"] }
 tokio-util = { version = "0.7.12", optional = true, features = ["codec"] }
 tracing = "0.1"
-irpc = { version = "0.7.0", optional = true, default-features = false, features = [
+irpc = { version = "0.8.0", optional = true, default-features = false, features = [
     "derive",
     "stream",
     "spans",
@@ -105,13 +105,13 @@ tokio = { version = "1", features = [
 ] }
 clap = { version = "4", features = ["derive"] }
 humantime-serde = { version = "1.1.1" }
-iroh = { version = "0.91", default-features = false, features = [
+iroh = { version = "0.92", default-features = false, features = [
     "metrics",
     "test-utils",
 ] }
 rand_chacha = "0.3.1"
 testresult = "0.4.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tracing-test = "0.2.5"
 url = "2.4.0"
 
@@ -178,8 +178,3 @@ debug = true
 
 [profile.release]
 debug = true
-
-[patch.crates-io]
-iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
-iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
-irpc = { git = "https://github.com/n0-computer/irpc.git", branch = "iroh-0-92" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,3 +178,8 @@ debug = true
 
 [profile.release]
 debug = true
+
+[patch.crates-io]
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+irpc = { git = "https://github.com/n0-computer/irpc.git", branch = "iroh-0-92" }

--- a/src/net.rs
+++ b/src/net.rs
@@ -571,7 +571,7 @@ impl Actor {
                 let WithChannels {
                     inner,
                     rx,
-                    mut tx,
+                    tx,
                     // TODO(frando): make use of span?
                     span: _,
                 } = msg;


### PR DESCRIPTION
## Description

In prep for the `iroh-gossip` 0.92 release, this upgrades `iroh`, `iror-base`, `irpc`, `tracing-subscriber` and `n0-snafu`