### PR TITLE
feat: set custom ALPN

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -1715,8 +1715,8 @@ pub(crate) mod test {
 
         let ep1 = Endpoint::builder().bind().await?;
         let ep2 = Endpoint::builder().bind().await?;
-        let gossip1 = Gossip::builder().alpn(&alpn).spawn(ep1.clone());
-        let gossip2 = Gossip::builder().alpn(&alpn).spawn(ep2.clone());
+        let gossip1 = Gossip::builder().alpn(alpn).spawn(ep1.clone());
+        let gossip2 = Gossip::builder().alpn(alpn).spawn(ep2.clone());
         let router1 = Router::builder(ep1).accept(alpn, gossip1.clone()).spawn();
         let router2 = Router::builder(ep2).accept(alpn, gossip2.clone()).spawn();
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -8,6 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 
+use bytes::Bytes;
 use futures_concurrency::stream::{stream_group, StreamGroup};
 use futures_util::FutureExt as _;
 use iroh::{
@@ -150,7 +151,7 @@ impl ProtocolHandler for Gossip {
 #[derive(Debug, Clone)]
 pub struct Builder {
     config: proto::Config,
-    alpn: Option<Vec<u8>>,
+    alpn: Option<Bytes>,
 }
 
 impl Builder {
@@ -181,7 +182,7 @@ impl Builder {
     ///
     /// [`RouterBuilder::accept`]: iroh::protocol::RouterBuilder::accept
     pub fn alpn(mut self, alpn: impl AsRef<[u8]>) -> Self {
-        self.alpn = Some(alpn.as_ref().to_vec());
+        self.alpn = Some(alpn.as_ref().to_vec().into());
         self
     }
 
@@ -263,7 +264,7 @@ impl Gossip {
 
 /// Actor that sends and handles messages between the connection and main state loops
 struct Actor {
-    alpn: Vec<u8>,
+    alpn: Bytes,
     /// Protocol state
     state: proto::State<PublicKey, StdRng>,
     /// The endpoint through which we dial peers
@@ -298,7 +299,7 @@ impl Actor {
         endpoint: Endpoint,
         config: proto::Config,
         metrics: Arc<Metrics>,
-        alpn: Option<Vec<u8>>,
+        alpn: Option<Bytes>,
     ) -> (
         Self,
         mpsc::Sender<RpcMessage>,
@@ -317,7 +318,7 @@ impl Actor {
         let (in_event_tx, in_event_rx) = mpsc::channel(IN_EVENT_CAP);
 
         let actor = Actor {
-            alpn: alpn.unwrap_or_else(|| GOSSIP_ALPN.to_vec()),
+            alpn: alpn.unwrap_or_else(|| GOSSIP_ALPN.to_vec().into()),
             endpoint,
             state,
             dialer,
@@ -1006,7 +1007,7 @@ impl Dialer {
     }
 
     /// Starts to dial a node by [`NodeId`].
-    fn queue_dial(&mut self, node_id: NodeId, alpn: Vec<u8>) {
+    fn queue_dial(&mut self, node_id: NodeId, alpn: Bytes) {
         if self.is_pending(node_id) {
             return;
         }
@@ -1703,6 +1704,37 @@ pub(crate) mod test {
         assert!(join_handle_1.join().unwrap().is_none());
         assert!(join_handle_2.join().unwrap().is_none());
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn gossip_change_alpn() -> n0_snafu::Result<()> {
+        let alpn = b"my-gossip-alpn";
+        let topic_id = TopicId::from([0u8; 32]);
+
+        let ep1 = Endpoint::builder().bind().await?;
+        let ep2 = Endpoint::builder().bind().await?;
+        let gossip1 = Gossip::builder().alpn(&alpn).spawn(ep1.clone());
+        let gossip2 = Gossip::builder().alpn(&alpn).spawn(ep2.clone());
+        let router1 = Router::builder(ep1).accept(alpn, gossip1.clone()).spawn();
+        let router2 = Router::builder(ep2).accept(alpn, gossip2.clone()).spawn();
+
+        let addr1 = router1.endpoint().node_addr().initialized().await;
+        let id1 = addr1.node_id;
+        router2.endpoint().add_node_addr(addr1)?;
+
+        let mut topic1 = gossip1.subscribe(topic_id, vec![]).await?;
+        let mut topic2 = gossip2.subscribe(topic_id, vec![id1]).await?;
+
+        timeout(Duration::from_secs(3), topic1.joined())
+            .await
+            .e()??;
+        timeout(Duration::from_secs(3), topic2.joined())
+            .await
+            .e()??;
+        router1.shutdown().await.e()?;
+        router2.shutdown().await.e()?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

Allow to customize the ALPN for outgoing gossip connections.

Also updates cargo deps (had cargo-deny warnings otherwise).

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [ ] All breaking changes documented.
