### PR TITLE
added debug log to show when dupe messages are received

### DIFF
--- a/src/proto/plumtree.rs
+++ b/src/proto/plumtree.rs
@@ -502,6 +502,7 @@ impl<PI: PeerIdentity> State<PI> {
         // if we already received this message: move peer to lazy set
         // and notify peer about this.
         if self.received_messages.contains_key(&message.id) {
+            debug!("Received duplicate message... ignoring");
             self.add_lazy(sender);
             io.push(OutEvent::SendMessage(sender, Message::Prune));
         // otherwise store the message, emit to application and forward to peers


### PR DESCRIPTION
## Description

Just adds a debug log to show when dupe messages are received.

## Breaking Changes
none

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
