### PR TITLE
perf: don't allocate in `Timers::wait_next`

### DIFF
--- a/src/net/util.rs
+++ b/src/net/util.rs
@@ -11,7 +11,10 @@ use iroh::{
     endpoint::{Connection, RecvStream, SendStream},
     NodeId,
 };
-use n0_future::{time::Instant, FuturesUnordered, StreamExt};
+use n0_future::{
+    time::{sleep_until, Instant},
+    FuturesUnordered, StreamExt,
+};
 use nested_enum_utils::common_fields;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use snafu::Snafu;
@@ -415,7 +418,7 @@ impl<T> Timers<T> {
         match self.map.first() {
             None => std::future::pending::<Instant>().await,
             Some(instant) => {
-                tokio::time::sleep_until(*instant).await;
+                sleep_until(*instant).await;
                 *instant
             }
         }

--- a/src/net/util.rs
+++ b/src/net/util.rs
@@ -3,7 +3,6 @@
 use std::{
     collections::{hash_map, HashMap},
     io,
-    pin::Pin,
     time::Duration,
 };
 
@@ -12,10 +11,7 @@ use iroh::{
     endpoint::{Connection, RecvStream, SendStream},
     NodeId,
 };
-use n0_future::{
-    time::{sleep_until, Instant, Sleep},
-    FuturesUnordered, StreamExt,
-};
+use n0_future::{time::Instant, FuturesUnordered, StreamExt};
 use nested_enum_utils::common_fields;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use snafu::Snafu;
@@ -392,14 +388,12 @@ pub async fn write_frame<T: Serialize>(
 /// A [`TimerMap`] with an async method to wait for the next timer expiration.
 #[derive(Debug)]
 pub struct Timers<T> {
-    next: Option<(Instant, Pin<Box<Sleep>>)>,
     map: TimerMap<T>,
 }
 
 impl<T> Default for Timers<T> {
     fn default() -> Self {
         Self {
-            next: None,
             map: TimerMap::default(),
         }
     }
@@ -416,22 +410,14 @@ impl<T> Timers<T> {
         self.map.insert(instant, item);
     }
 
-    fn reset(&mut self) {
-        self.next = self
-            .map
-            .first()
-            .map(|instant| (*instant, Box::pin(sleep_until(*instant))))
-    }
-
     /// Waits for the next timer to elapse.
     pub async fn wait_next(&mut self) -> Instant {
-        self.reset();
-        match self.next.as_mut() {
-            Some((instant, sleep)) => {
-                sleep.await;
+        match self.map.first() {
+            None => std::future::pending::<Instant>().await,
+            Some(instant) => {
+                tokio::time::sleep_until(*instant).await;
                 *instant
             }
-            None => std::future::pending().await,
         }
     }
 


### PR DESCRIPTION
## Description

While doing some memory profiling on iroh-gossip I found an allocation that is not needed. It can get quite hot, so good to save this.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
