### PR TITLE
chore: update nightly version in CI and docs workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -232,7 +232,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-11-30
+        toolchain: nightly-2025-10-09
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.9
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-11-30
+        toolchain: nightly-2025-10-09
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.9
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! [iroh]: https://docs.rs/iroh
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
-#![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "net")]
 #[doc(inline)]


### PR DESCRIPTION
## Description

rustdocs is broken because we are using a feature that no longer exists in nightly.

this updates our workflows to use a more recent version of nightly and also adjusts the naming of the feature in question
