### PR TITLE
chore: release prep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,8 +1787,7 @@ dependencies = [
 [[package]]
 name = "iroh"
 version = "0.90.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9436f319c2d24bca1b28a2fab4477c8d2ac795ab2d3aeda142d207b38ec068f4"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#9c023bf4d7d1c3c10a9cc3b10df7e1a22c6ab7a4"
 dependencies = [
  "aead",
  "axum",
@@ -1849,8 +1848,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.90.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0090050c4055b21e61cbcb856f043a2b24ad22c65d76bab91f121b4c7bece3"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#9c023bf4d7d1c3c10a9cc3b10df7e1a22c6ab7a4"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -1998,8 +1996,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "0.90.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f3cdbdaebc92835452e4e1d0d4b36118206b0950089b7bc3654f13e843475b"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#9c023bf4d7d1c3c10a9cc3b10df7e1a22c6ab7a4"
 dependencies = [
  "ahash",
  "bytes",
@@ -2062,8 +2059,7 @@ dependencies = [
 [[package]]
 name = "irpc"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b355fe12226ee885e1c1056a867c2cf37be2b22032a16f5ab7091069e98a966f"
+source = "git+https://github.com/n0-computer/irpc.git?branch=main#5cc624832cfed2653a20442851c203935039d6bc"
 dependencies = [
  "anyhow",
  "futures-buffered",
@@ -2085,8 +2081,7 @@ dependencies = [
 [[package]]
 name = "irpc-derive"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efeabe1ee5615ea0416340b1a6d71a16f971495859c87fad48633b6497ee7a77"
+source = "git+https://github.com/n0-computer/irpc.git?branch=main#5cc624832cfed2653a20442851c203935039d6bc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,3 +183,8 @@ debug = true
 
 [profile.release]
 debug = true
+
+[patch.crates-io]
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+irpc = { git = "https://github.com/n0-computer/irpc.git", branch = "main" }
+iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -38,3 +38,9 @@ name = "ring"
 [[licenses.clarify.license-files]]
 hash = 3171872035
 path = "LICENSE"
+
+[sources]
+allow-git = [
+    "https://github.com/n0-computer/iroh.git",
+    "https://github.com/n0-computer/irpc.git",
+]


### PR DESCRIPTION
This PR updates the following dependencies to their latest versions:

- `iroh` from `https://github.com/n0-computer/iroh.git`
- `irpc` from `https://github.com/n0-computer/irpc.git`
- `iroh-base` from `https://github.com/n0-computer/iroh.git`