### PR TITLE
fix: recover from RwLock poisoning instead of panicking

### DIFF
--- a/src/net/address_lookup.rs
+++ b/src/net/address_lookup.rs
@@ -75,7 +75,7 @@ impl GossipAddressLookup {
                         break;
                     };
                     let now = SystemTime::now();
-                    endpoints.write().expect("poisoned").retain(|_k, v| {
+                    endpoints.write().unwrap_or_else(|e| e.into_inner()).retain(|_k, v| {
                         let age = now.duration_since(v.last_updated).unwrap_or(Duration::MAX);
                         age <= opts.retention
                     });
@@ -96,7 +96,7 @@ impl GossipAddressLookup {
     pub(crate) fn add(&self, endpoint_info: impl Into<EndpointInfo>) {
         let last_updated = SystemTime::now();
         let EndpointInfo { endpoint_id, data } = endpoint_info.into();
-        let mut guard = self.endpoints.write().expect("poisoned");
+        let mut guard = self.endpoints.write().unwrap_or_else(|e| e.into_inner());
         match guard.entry(endpoint_id) {
             Entry::Occupied(mut entry) => {
                 let existing = entry.get_mut();
@@ -116,7 +116,7 @@ impl AddressLookup for GossipAddressLookup {
         &self,
         endpoint_id: EndpointId,
     ) -> Option<BoxStream<Result<address_lookup::Item, address_lookup::Error>>> {
-        let guard = self.endpoints.read().expect("poisoned");
+        let guard = self.endpoints.read().unwrap_or_else(|e| e.into_inner());
         let info = guard.get(&endpoint_id)?;
         let last_updated = info
             .last_updated

--- a/src/net/address_lookup.rs
+++ b/src/net/address_lookup.rs
@@ -75,10 +75,13 @@ impl GossipAddressLookup {
                         break;
                     };
                     let now = SystemTime::now();
-                    endpoints.write().unwrap_or_else(|e| e.into_inner()).retain(|_k, v| {
-                        let age = now.duration_since(v.last_updated).unwrap_or(Duration::MAX);
-                        age <= opts.retention
-                    });
+                    endpoints
+                        .write()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .retain(|_k, v| {
+                            let age = now.duration_since(v.last_updated).unwrap_or(Duration::MAX);
+                            age <= opts.retention
+                        });
                 }
             })
         };


### PR DESCRIPTION
## Summary
- Replace `.expect("poisoned")` with `.unwrap_or_else(|e| e.into_inner())` on all RwLock acquisitions in address_lookup.rs
- Recovers the inner data from a poisoned lock instead of cascading panics

## Test plan
- [x] All 19 tests pass
- [x] `cargo make format-check` passes
- [x] `cargo clippy -- -D warnings` passes