### PR TITLE
fix: use consistent message size comparison on read and write paths

### DIFF
--- a/src/net/util.rs
+++ b/src/net/util.rs
@@ -381,7 +381,7 @@ pub async fn write_frame<T: Serialize>(
     max_message_size: usize,
 ) -> Result<(), WriteError> {
     let len = postcard::experimental::serialized_size(&message)?;
-    if len >= max_message_size {
+    if len > max_message_size {
         return Err(e!(WriteError::TooLarge));
     }
     buffer.clear();


### PR DESCRIPTION
## Summary
- Align write-path size check from `>=` to `>` to match the read path
- Previously a message exactly at `max_message_size` would be rejected on write but accepted on read

## Test plan
- [x] All 19 tests pass
- [x] `cargo make format-check` passes
- [x] `cargo clippy -- -D warnings` passes