### PR TITLE
fix(net): handle JoinError::Cancelled gracefully in actor event loop

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -465,15 +465,45 @@ impl Actor {
             }
             Some(res) = self.connection_tasks.join_next(), if !self.connection_tasks.is_empty() => {
                 trace!(?i, "tick: connection_tasks");
-                let (peer_id, conn, result) = res.expect("connection task panicked");
-                self.handle_connection_task_finished(peer_id, conn, result).await;
+                match res {
+                    Ok((peer_id, conn, result)) => {
+                        self.handle_connection_task_finished(peer_id, conn, result).await;
+                    }
+                    Err(err) if err.is_cancelled() => {
+                        // The task was aborted (e.g. via JoinSet::abort_all
+                        // on actor shutdown, or via a connection task's
+                        // AbortHandle held elsewhere). Continue the
+                        // event loop rather than panicking the actor.
+                        warn!(
+                            ?err,
+                            "connection task cancelled; continuing event loop"
+                        );
+                    }
+                    Err(err) => {
+                        // Genuine task panic — preserve the existing
+                        // panic-on-bug behaviour so it is not silenced.
+                        panic!("connection task panicked: {err}");
+                    }
+                }
             }
             Some(res) = self.topic_event_forwarders.join_next(), if !self.topic_event_forwarders.is_empty() => {
-                let topic_id = res.expect("topic event forwarder panicked");
-                if let Some(state) = self.topics.get_mut(&topic_id) {
-                    if !state.still_needed() {
-                        self.quit_queue.push_back(topic_id);
-                        self.process_quit_queue().await;
+                match res {
+                    Ok(topic_id) => {
+                        if let Some(state) = self.topics.get_mut(&topic_id) {
+                            if !state.still_needed() {
+                                self.quit_queue.push_back(topic_id);
+                                self.process_quit_queue().await;
+                            }
+                        }
+                    }
+                    Err(err) if err.is_cancelled() => {
+                        warn!(
+                            ?err,
+                            "topic event forwarder cancelled; continuing event loop"
+                        );
+                    }
+                    Err(err) => {
+                        panic!("topic event forwarder panicked: {err}");
                     }
                 }
             }
@@ -1971,6 +2001,96 @@ pub(crate) mod tests {
         drop(rx2);
         router1.shutdown().await.std_context("shutdown router1")?;
         router2.shutdown().await.std_context("shutdown router2")?;
+        Ok(())
+    }
+
+    /// Regression test for issue #140.
+    ///
+    /// When a task in `Actor::connection_tasks` ends via
+    /// `JoinError::Cancelled` — possible whenever the task is aborted
+    /// directly (e.g. via the `JoinSet`'s `AbortHandle`) or whenever
+    /// the actor's parent task is cancelled while connection tasks
+    /// are in flight — the previous `.expect("connection task panicked")`
+    /// at the `connection_tasks.join_next()` branch of `Actor::tick`
+    /// panicked the actor task itself. Result: the entire gossip
+    /// subsystem stops processing commands (its `to_actor_rx` has no
+    /// live consumer), so every subsequent `subscribe`, `broadcast`,
+    /// or topic event delivery hangs indefinitely with no diagnostic.
+    ///
+    /// This test injects a pending task into `connection_tasks`,
+    /// aborts it, and drives one `Actor::event_loop` tick. Without
+    /// the fix it panics inside `tick`; with the fix it logs a
+    /// warning and continues.
+    #[tokio::test]
+    #[traced_test]
+    async fn actor_survives_cancelled_connection_task() -> Result {
+        let rng = &mut rand::rngs::ChaCha12Rng::seed_from_u64(1);
+        let ct = CancellationToken::new();
+        let (relay_map, _relay_url, _guard) = iroh::test_utils::run_relay_server().await.unwrap();
+
+        let (_gossip, actor, _ep_handle) =
+            Gossip::t_new_with_actor(rng, Default::default(), relay_map, &ct).await?;
+        let mut actor = ManualActorLoop::new(actor).await;
+
+        // Inject a pending task into `connection_tasks`. The future
+        // never resolves on its own; aborting forces the JoinSet to
+        // yield `Err(JoinError::Cancelled)` on the next `join_next()`.
+        let handle = actor.connection_tasks.spawn(async {
+            std::future::pending::<(
+                EndpointId,
+                iroh::endpoint::Connection,
+                Result<(), ConnectionLoopError>,
+            )>()
+            .await
+        });
+        handle.abort();
+
+        // Drive one tick under a hard timeout. Without the fix `tick`
+        // panics inside `tokio::select!` when it hits the cancelled
+        // task. With the fix it routes through the new `match` arm,
+        // logs a warning, and returns `true` (actor still running).
+        let still_running = timeout(Duration::from_secs(5), actor.step())
+            .await
+            .std_context("actor.step() should return promptly after cancelled task")?;
+        assert!(
+            still_running,
+            "actor should keep running after a cancelled connection task"
+        );
+
+        ct.cancel();
+        Ok(())
+    }
+
+    /// Regression test for issue #140 — second JoinSet variant.
+    ///
+    /// Same failure mode as `actor_survives_cancelled_connection_task`
+    /// but exercises `Actor::topic_event_forwarders`, which had the
+    /// same `.expect("topic event forwarder panicked")` defect.
+    #[tokio::test]
+    #[traced_test]
+    async fn actor_survives_cancelled_topic_event_forwarder() -> Result {
+        let rng = &mut rand::rngs::ChaCha12Rng::seed_from_u64(2);
+        let ct = CancellationToken::new();
+        let (relay_map, _relay_url, _guard) = iroh::test_utils::run_relay_server().await.unwrap();
+
+        let (_gossip, actor, _ep_handle) =
+            Gossip::t_new_with_actor(rng, Default::default(), relay_map, &ct).await?;
+        let mut actor = ManualActorLoop::new(actor).await;
+
+        let handle = actor
+            .topic_event_forwarders
+            .spawn(async { std::future::pending::<TopicId>().await });
+        handle.abort();
+
+        let still_running = timeout(Duration::from_secs(5), actor.step())
+            .await
+            .std_context("actor.step() should return promptly after cancelled forwarder")?;
+        assert!(
+            still_running,
+            "actor should keep running after a cancelled topic event forwarder"
+        );
+
+        ct.cancel();
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Fixes #140. The actor's `tick` matched on `connection_tasks.join_next()` and `topic_event_forwarders.join_next()` with `.expect("…task panicked")`. `JoinSet::join_next` returns `Result<T, JoinError>`, where `JoinError` can represent either a panic **or** a cancellation. The previous handling panicked the actor task on **either**, meaning any cancellation of a connection task or topic event forwarder (e.g. via `JoinSet::abort_all`, or via any `AbortHandle` held outside the JoinSet) killed the actor's `event_loop` itself. Once dead, the actor's command receiver has no live consumer, so every subsequent `subscribe`, `broadcast`, and topic event delivery hangs indefinitely with no log line beyond the original panic.

## Fix

`match` on the `join_next()` result instead. `warn!` and continue the event loop on `is_cancelled()`. Preserve the existing `panic!` for genuine task panics so real bugs stay loud.

```rust
match res {
    Ok((peer_id, conn, result)) => {
        self.handle_connection_task_finished(peer_id, conn, result).await;
    }
    Err(err) if err.is_cancelled() => {
        warn!(?err, "connection task cancelled; continuing event loop");
    }
    Err(err) => {
        panic!("connection task panicked: {err}");
    }
}
```

Same shape for `topic_event_forwarders`. ~+50 LoC of fix + comments.

## Regression tests

Two tests in `src/net.rs::tests` exercise both JoinSets independently:

- `actor_survives_cancelled_connection_task` — spawns a pending task into `Actor::connection_tasks`, aborts it via the returned `AbortHandle`, drives one `event_loop` tick under a 5s timeout, and asserts `tick` returned without panicking.
- `actor_survives_cancelled_topic_event_forwarder` — same shape against the `topic_event_forwarders` JoinSet.

**On unpatched master**, both fail deterministically:

```
thread 'net::tests::actor_survives_cancelled_connection_task' panicked at src/net.rs:468:51:
connection task panicked: JoinError::Cancelled(Id(66))

thread 'net::tests::actor_survives_cancelled_topic_event_forwarder' panicked at src/net.rs:472:36:
topic event forwarder panicked: JoinError::Cancelled(Id(65))

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 19 filtered out; finished in 0.25s
```

**With the fix**, both pass:

```
test net::tests::actor_survives_cancelled_connection_task ... ok
test net::tests::actor_survives_cancelled_topic_event_forwarder ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out; finished in 0.27s
```

## In-the-wild reproduction

Surfaced in a downstream consumer of iroh-gossip via two independent workflows:

1. **Warm-restart multi-device E2E** (Docker NAT, post-pair broadcast burst).
2. **Host-to-host bench-prep flow** (no NAT, sparser broadcast pattern).

The user-visible symptom in both: every `gossip.subscribe()` and `broadcast()` hangs forever after some prior connection task ended via cancellation. No log line beyond the actor panic, which is itself swallowed by the spawn boundary above.

(Note: NAOMS also independently observed and patched the wedge mechanism described in #47 — `.send().await` on a bounded per-peer mpsc blocking the entire actor under stuck-peer backpressure. That is a separate failure mode; this PR only addresses #140. We are happy to discuss the #47-class wedge in a separate issue/PR once we have an isolated reproducer.)

## Compatibility

- No public API changes.
- `JoinError::is_cancelled` is on tokio's stable API; `n0_future::task::JoinError` re-exports tokio's directly so the call sites work unchanged.
- Behavior change is strictly narrower-than-panic: cancellations that previously crashed the actor now warn-and-continue; genuine panics still panic.
