### PR TITLE
fix(net): drop wedged peer after K consecutive try_send Full failures

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -53,6 +53,13 @@ const TO_ACTOR_CAP: usize = 64;
 const IN_EVENT_CAP: usize = 1024;
 /// Channel capacity for broadcast subscriber event queue (one per topic)
 const TOPIC_EVENT_CAP: usize = 256;
+/// Consecutive `try_send` Full failures on a peer's per-connection send-loop
+/// channel before the actor force-drops the peer to break out of a stuck-
+/// peer wedge.
+///
+/// See `OutEvent::SendMessage` below for the wedge mechanism this guards
+/// against — addresses the failure mode described in #47.
+const SEND_FULL_FAILURES_TO_DROP_PEER: u32 = 8;
 
 /// Events emitted from the gossip protocol
 pub type ProtoEvent = proto::Event<PublicKey>;
@@ -303,6 +310,13 @@ struct Actor {
     metrics: Arc<Metrics>,
     topic_event_forwarders: JoinSet<TopicId>,
     address_lookup: GossipAddressLookup,
+    /// Per-peer counter of consecutive `try_send` Full failures on the
+    /// per-connection send-loop channel. Reset on Ok / Closed; on
+    /// `>= SEND_FULL_FAILURES_TO_DROP_PEER` the actor drops the peer
+    /// from `peers`, which closes its `send_tx` end-of-channel → SendLoop
+    /// exits → connection task finishes → existing
+    /// `handle_connection_task_finished` path emits `PeerDisconnected`.
+    send_full_failures: HashMap<EndpointId, u32>,
 }
 
 impl Actor {
@@ -347,6 +361,7 @@ impl Actor {
             local_rx,
             topic_event_forwarders: Default::default(),
             address_lookup,
+            send_full_failures: Default::default(),
         };
 
         (actor, rpc_tx, local_tx)
@@ -681,13 +696,86 @@ impl Actor {
                     let state = self.peers.entry(peer_id).or_default();
                     match state {
                         PeerState::Active { active_send_tx, .. } => {
-                            if let Err(_err) = active_send_tx.send(message).await {
-                                // Removing the peer is handled by the in_event PeerDisconnected sent
-                                // in [`Self::handle_connection_task_finished`].
-                                warn!(
-                                    peer = %peer_id.fmt_short(),
-                                    "failed to send: connection task send loop terminated",
-                                );
+                            // Bounded `try_send` + consecutive-Full counter,
+                            // dropping the peer after K consecutive Full
+                            // failures.
+                            //
+                            // Previously this was `.send(message).await`,
+                            // which blocks the entire actor `tokio::select!`
+                            // loop whenever ONE peer's per-connection
+                            // `SendLoop` cannot drain its `send_rx`
+                            // (e.g. a stuck/half-open QUIC stream on a
+                            // NAT-degraded peer, or any "neighbor that
+                            // accepted into the active view but no longer
+                            // drains data" condition). Once the actor is
+                            // blocked on `.send().await`, NO other branch
+                            // of the `select!` advances — including the
+                            // connection-task-finished branch that would
+                            // otherwise demote the wedged peer via
+                            // `NeighborDown`. `.send().await` never
+                            // returns `Full` on a bounded channel, so the
+                            // actor has no signal to escape; the wedge is
+                            // process-wide and persistent. This is the
+                            // failure mode described in issue #47.
+                            //
+                            // `try_send` lets the actor observe `Full`,
+                            // count consecutive occurrences per-peer, and
+                            // — at threshold — drop the wedged peer's
+                            // `PeerState`. Dropping closes `send_tx`'s
+                            // end of the channel, which signals
+                            // `SendLoop`'s `send_rx.recv()` → `None`,
+                            // the connection task exits, and the existing
+                            // `handle_connection_task_finished` path
+                            // emits `PeerDisconnected` cleanly. Healthy
+                            // peers — whose SendLoops drain at line
+                            // rate — never accumulate Full counts because
+                            // any `Ok` resets the counter.
+                            //
+                            // Plumtree's eager-push protocol tolerates
+                            // best-effort delivery (recovery is via the
+                            // lazy-pull REQUEST/PRUNE backstop), so the
+                            // dropped messages on Full are consistent
+                            // with the protocol's at-most-once-per-eager
+                            // contract.
+                            match active_send_tx.try_send(message) {
+                                Ok(()) => {
+                                    self.send_full_failures.remove(&peer_id);
+                                }
+                                Err(mpsc::error::TrySendError::Full(_)) => {
+                                    let counter = self
+                                        .send_full_failures
+                                        .entry(peer_id)
+                                        .and_modify(|c| *c += 1)
+                                        .or_insert(1);
+                                    let consecutive_failures = *counter;
+                                    warn!(
+                                        peer = %peer_id.fmt_short(),
+                                        consecutive_failures,
+                                        "send queue full; will drop peer after {} consecutive failures",
+                                        SEND_FULL_FAILURES_TO_DROP_PEER,
+                                    );
+                                    if consecutive_failures >= SEND_FULL_FAILURES_TO_DROP_PEER {
+                                        warn!(
+                                            peer = %peer_id.fmt_short(),
+                                            consecutive_failures,
+                                            "dropping wedged peer after {} consecutive send-queue-full failures",
+                                            SEND_FULL_FAILURES_TO_DROP_PEER,
+                                        );
+                                        self.peers.remove(&peer_id);
+                                        self.send_full_failures.remove(&peer_id);
+                                    }
+                                }
+                                Err(mpsc::error::TrySendError::Closed(_)) => {
+                                    // Receiver gone; the existing
+                                    // PeerDisconnected path via
+                                    // `handle_connection_task_finished`
+                                    // will land for this peer.
+                                    warn!(
+                                        peer = %peer_id.fmt_short(),
+                                        "failed to send: connection task send loop terminated",
+                                    );
+                                    self.send_full_failures.remove(&peer_id);
+                                }
                             }
                         }
                         PeerState::Pending { queue } => {


### PR DESCRIPTION
## Summary

Addresses #47 — gossip backpressure leads to process-wide unresponsive actor under a stuck-peer condition.

The `OutEvent::SendMessage` branch of `Actor::handle_out_event` uses `.send(message).await` on a bounded per-peer mpsc (`SEND_QUEUE_CAP = 64`). If any **one** peer's per-connection `SendLoop` cannot drain its `send_rx` — e.g. a half-open / NAT-degraded QUIC stream, or a peer that accepted into the active view but no longer reads — the actor's single `tokio::select!` loop blocks on that `.await`. While blocked, **no other branch advances**:

- other peers' `SendMessage` are queued behind the stuck one,
- `in_event_rx` (commands, subscriptions, broadcasts) is not polled,
- timers don't fire,
- `connection_tasks.join_next()` doesn't observe the wedged peer's task ending.

Crucially, the actor can't `NeighborDown` its way out — `.send().await` on a bounded mpsc **never** returns `Full`, it just hangs forever. The wedge is process-wide, persistent, and externally indistinguishable from a hang: every subsequent `subscribe()` / `broadcast()` times out, and a *fresh* `gossip.subscribe()` issued through the unwedged API also hangs at 30s because the actor's command receiver has no live consumer making progress.

## Fix

Replace `.send().await` with `try_send` + a per-peer consecutive-`Full` counter. After `SEND_FULL_FAILURES_TO_DROP_PEER = 8` consecutive Full failures the actor drops the peer's `PeerState`, which closes `send_tx`'s end of the channel → `SendLoop::send_rx.recv()` returns `None` → the connection task exits cleanly → the existing `handle_connection_task_finished` path fires `PeerDisconnected` and removes the peer from hyparview. The actor regains liveness without any new event-loop branches.

The counter resets on `Ok(())` so healthy peers — whose SendLoops drain at line rate — never accumulate Full counts. It also resets on `Closed`, leaving the existing PeerDisconnected machinery as the single path for that case.

Plumtree's eager-push tolerates best-effort delivery (lazy-pull `REQUEST` / `PRUNE` are the recovery backstop), so the messages dropped on Full are consistent with the protocol's at-most-once-per-eager-push contract.

## Why K = 8

Heuristic, not bisected. At the post-pair-burst load profile that triggers the wedge in our downstream workflows, K = 8 corresponds to roughly a sub-second drop window before the wedged peer is force-removed — small enough to recover the actor promptly, large enough to absorb transient backpressure spikes. We have run with this threshold for the wedge-fix branch since the patch shipped; the empirical signal is "0 wedge fires vs 3+ per E2E run pre-patch" plus uneventful steady-state behavior, not a bisection.

I'm happy to make this configurable, raise/lower the default, or split it from `SEND_QUEUE_CAP` into a builder option if you'd prefer a different shape. The number itself is the least load-bearing part of the change.

## Reproduction

The wedge has been reproduced in two independent downstream workflows that share no infrastructure:

1. **A two-process E2E** (Docker NAT + post-pair broadcast burst on a freshly-joined 2-node hyparview mesh): wedge at ~17s after the burst.
2. **A host-to-host benchmark prep flow** (no NAT, sparser broadcasts): wedge at ~5min, same observable signature.

In both: every subsequent broadcast times out, fresh `subscribe()` times out, unicast endpoint operations remain healthy (ruling out endpoint-level QUIC failure).

**A fully isolated reproducer test is in progress** in a separate sandbox — the approach is a minimal custom `ProtocolHandler` that speaks the iroh-gossip ALPN, completes `JOIN` / `NEIGHBOR_HIGH_PRIORITY` so the publisher promotes it into the active view, then stops accepting further uni-streams (synthetic QUIC-stream-slow peer). I'll attach that to this PR when it's green — it should let CI reproduce the failure deterministically. If you'd prefer to wait for that before reviewing, please say so; I'm filing this now to surface the fix shape and get directional feedback from maintainers.

## Compatibility

- No public API changes.
- Behavior changes for `Active` peers only:
  - Healthy peers: identical (counter never advances past 0).
  - Wedged peers: now eventually demoted (~8 send attempts × tick rate) instead of wedging the entire actor.
  - The dropped-message visibility is consistent with the documented Plumtree eager-push contract; lazy-pull provides the recovery path.
- Existing test suite passes (19 tests, no changes needed).

## Notes

This PR is paired with #142, which fixes #140 (panic on `JoinError::Cancelled`). The two are independent failure modes — this one (the actor wedge on stuck-peer backpressure) is the higher-impact bug; #140 is a real but orthogonal issue that empirically does not fire in the workflows that produced the wedge in our deployments, but is worth fixing as defense-in-depth.

## Empirical addendum (2026-05-15)

I checked the warm-E2E logs for `try_send` Full activity after the patch shipped. **Zero `try_send full for peer` warnings, zero `consecutive_failures` counter advances** across both v50d (K=8 alone) and v50e (K=8 + #140 fix) runs. The K = 8 ratchet path never actually fires under the observed load.

This shifts the narrative slightly:

- The wedge wasn't from sustained Full backpressure on a chronically-stuck per-peer channel. It was from `.send().await` blocking the actor on a *momentarily* Full channel that would have drained on the next tick — if the actor weren't blocked from processing the connection-task-finished events for the *other* peers (classic head-of-line blocking the head-of-line).
- The load-bearing change is `try_send` itself, not the K = 8 force-drop. Once the actor stops awaiting on a single channel slot, the channel drains on its own, no Full counter ever needs to advance.

Implication: the K = 8 threshold value is irrelevant in our observed profile. If maintainers prefer a simpler fix shape — `try_send` + immediate `NeighborDown` on Full, no counter, no per-peer state — I'd be happy to submit that variant. Plumtree's at-most-once-per-eager-push tolerance covers the message drop on Full either way. The current K = 8 shape is closer to the prior downstream-fork carry-over; the simpler shape is closer to what an idiomatic upstream patch would look like.

Independent corroboration: a second downstream consumer (a bench-prep flow with no NAT, host-to-host, sparser broadcasts) reproduced the same wedge and confirms the same `try_send`-replaces-`.send().await` shape resolves it. They also independently surfaced #47 + #140 from the issue tracker before this PR was filed.

Happy to update the PR with whichever shape you prefer; signal in review which way to go.
