### PR TITLE
fix(iroh-gossip): reap connection tasks and prune peer state on churn

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -441,6 +441,8 @@ impl Actor {
                             self.handle_in_event(InEvent::PeerDisconnected(peer_id), Instant::now())
                                 .await;
                         }
+                        // Remove from active peers tracking map to reclaim connection resources on dial failure
+                        self.peers.remove(&peer_id);
                     }
                     None => {
                         warn!(peer = %peer_id.fmt_short(), "dial disconnected");
@@ -583,6 +585,8 @@ impl Actor {
                 debug!("active send connection closed, mark peer as disconnected");
                 self.handle_in_event(InEvent::PeerDisconnected(peer_id), Instant::now())
                     .await;
+                // Discard peer descriptor from tracking map upon connection closure to prevent connection descriptor leak
+                self.peers.remove(&peer_id);
             } else {
                 other_conns.retain(|x| *x != conn.stable_id());
                 debug!("remaining {} other connections", other_conns.len() + 1);
@@ -894,9 +898,15 @@ async fn connection_loop(
     let send_fut = send_loop.run(queue).instrument(error_span!("send"));
     let recv_fut = recv_loop.run().instrument(error_span!("recv"));
 
-    let (send_res, recv_res) = tokio::join!(send_fut, recv_fut);
-    send_res?;
-    recv_res?;
+    tokio::select! {
+        biased;
+        res = send_fut => {
+            res?;
+        }
+        res = recv_fut => {
+            res?;
+        }
+    }
     Ok(())
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -1544,6 +1544,69 @@ pub(crate) mod tests {
         Ok(())
     }
 
+    /// Regression test: a [`SendLoop`] must terminate once its send channel is
+    /// closed (all senders dropped), which is how a superseded or disconnected
+    /// connection is signalled — [`PeerState::accept_conn`] drops the old
+    /// connection's `send_tx`, and [`Actor::handle_in_event`] drops it on
+    /// `DisconnectPeer`.
+    ///
+    /// Previously the send loop's `select!` used `Some(msg) = recv()` plus an
+    /// `else => break`. That `else` was dead code: the biased `closed` branch
+    /// stayed enabled-and-pending, so the loop blocked on `closed` forever
+    /// instead of breaking when the channel closed. The connection (and its
+    /// `connection_loop`) then lived until the *peer* closed it — which under
+    /// keep-alive never happened — leaking one connection per churned link.
+    ///
+    /// [`SendLoop`]: util::SendLoop
+    #[tokio::test]
+    #[traced_test]
+    async fn send_loop_terminates_when_send_channel_closed() -> Result {
+        let rng = &mut rand::rngs::ChaCha12Rng::seed_from_u64(1);
+        let (relay_map, relay_url, _guard) =
+            iroh::test_utils::run_relay_server().await.unwrap();
+        let ep1 = create_endpoint(rng, relay_map.clone(), None).await?;
+        let ep2 = create_endpoint(rng, relay_map.clone(), None).await?;
+
+        // Let ep1 resolve ep2's address.
+        let memory_lookup = MemoryLookup::new();
+        memory_lookup.add_endpoint_info(EndpointAddr::new(ep2.id()).with_relay_url(relay_url));
+        ep1.address_lookup()?.add(memory_lookup);
+
+        let ep2_id = ep2.id();
+        // ep2 accepts the connection and holds it open (so the only thing that can
+        // make the send loop exit is the closed send channel, not the peer).
+        let accept_task = task::spawn(async move {
+            if let Some(incoming) = ep2.accept().await {
+                if let Ok(conn) = incoming.await {
+                    conn.closed().await;
+                }
+            }
+        });
+
+        let conn = ep1
+            .connect(ep2_id, GOSSIP_ALPN)
+            .await
+            .std_context("connect")?;
+
+        // A send channel whose only sender is immediately dropped models a
+        // just-superseded connection.
+        let (send_tx, send_rx) = mpsc::channel::<ProtoMessage>(1);
+        drop(send_tx);
+
+        // With the fix this returns promptly; with the bug it blocks on
+        // `conn.closed()` forever and the timeout fires.
+        let mut send_loop = util::SendLoop::new(conn, send_rx, 1024);
+        let res = timeout(Duration::from_secs(5), send_loop.run(vec![])).await;
+        assert!(
+            res.is_ok(),
+            "SendLoop must terminate when its send channel closes (superseded connection)"
+        );
+        res.expect("send loop returned").std_context("send loop run")?;
+
+        accept_task.abort();
+        Ok(())
+    }
+
     /// Test that endpoints can reconnect to each other.
     ///
     /// This test will create two endpoints subscribed to the same topic. The second endpoint will

--- a/src/net/util.rs
+++ b/src/net/util.rs
@@ -231,7 +231,16 @@ impl SendLoop {
             tokio::select! {
                 biased;
                 _ = &mut closed => break,
-                Some(msg) = self.send_rx.recv() => self.write_message(&msg).await?,
+                msg = self.send_rx.recv() => match msg {
+                    Some(msg) => self.write_message(&msg).await?,
+                    // All senders dropped = the peer was removed from the gossip
+                    // peer map; the send side is done, so break. With the old
+                    // `Some(msg) = recv()` form, a `None` silently DISABLED this
+                    // branch while `closed` stayed pending forever — SendLoop hung,
+                    // send_fut never resolved, connection_loop's select! never fired,
+                    // and the Connection + ConnectionDriver leaked (1 per removed peer).
+                    None => break,
+                },
                 _ = self.finishing.join_next(), if !self.finishing.is_empty() => {}
                 else => break,
             }

--- a/src/proto/hyparview.rs
+++ b/src/proto/hyparview.rs
@@ -772,3 +772,81 @@ enum RemovalReason {
     /// A peer is removed after random selection to make room for a newly joined peer.
     Random,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use super::*;
+    use crate::proto::topic::OutEvent as TopicOut;
+
+    fn state() -> State<u32, StdRng> {
+        State::new(0u32, None, Config::default(), StdRng::seed_from_u64(1))
+    }
+
+    // Regressions for n0-computer/iroh-gossip#146: per-peer metadata
+    // (`peer_data`, `alive_disconnect_peers`) must be pruned when a peer leaves,
+    // rather than accumulating as stale state under churn. One test per eviction
+    // path — revert that path's prune and only its test goes red.
+
+    #[test]
+    fn passive_view_eviction_prunes_metadata() {
+        let mut state = state();
+        state.config.passive_view_capacity = 1;
+        let mut io = VecDeque::<TopicOut<u32>>::new();
+        state.add_passive(10, None, &mut io); // passive view now {10}
+        state.peer_data.insert(10, PeerData::new(vec![1]));
+        state.alive_disconnect_peers.insert(10);
+        // Adding another peer evicts the (single) passive peer at random = 10.
+        state.add_passive(11, None, &mut io);
+        assert!(
+            !state.peer_data.contains_key(&10),
+            "passive-view eviction must prune peer_data"
+        );
+        assert!(
+            !state.alive_disconnect_peers.contains(&10),
+            "passive-view eviction must prune alive_disconnect_peers"
+        );
+    }
+
+    #[test]
+    fn pending_neighbor_timeout_prunes_metadata() {
+        let mut state = state();
+        let mut io = VecDeque::<TopicOut<u32>>::new();
+        let peer = 20;
+        state.pending_neighbor_requests.insert(peer);
+        state.passive_view.insert(peer);
+        state.peer_data.insert(peer, PeerData::new(vec![2]));
+        state.alive_disconnect_peers.insert(peer);
+        state.handle_pending_neighbor_timer(peer, &mut io);
+        assert!(
+            !state.peer_data.contains_key(&peer),
+            "pending-neighbor timeout must prune peer_data"
+        );
+        assert!(
+            !state.alive_disconnect_peers.contains(&peer),
+            "pending-neighbor timeout must prune alive_disconnect_peers"
+        );
+    }
+
+    #[test]
+    fn active_view_discard_prunes_metadata() {
+        let mut state = state();
+        let mut io = VecDeque::<TopicOut<u32>>::new();
+        let peer = 30;
+        state.active_view.insert(peer);
+        state.peer_data.insert(peer, PeerData::new(vec![3]));
+        // is_alive=false => not kept as passive => peer_data must be dropped.
+        state.remove_active(
+            &peer,
+            RemovalReason::DisconnectReceived { is_alive: false },
+            &mut io,
+        );
+        assert!(
+            !state.peer_data.contains_key(&peer),
+            "active-view discard (not kept) must prune peer_data"
+        );
+    }
+}

--- a/src/proto/hyparview.rs
+++ b/src/proto/hyparview.rs
@@ -580,7 +580,11 @@ where
             return;
         }
         if self.passive_is_full() {
-            self.passive_view.remove_random(&mut self.rng);
+            if let Some(evicted_peer) = self.passive_view.remove_random(&mut self.rng) {
+                // Clear metadata and eviction markers to prevent memory leaks from accumulated stale descriptors
+                self.peer_data.remove(&evicted_peer);
+                self.alive_disconnect_peers.remove(&evicted_peer);
+            }
         }
         self.passive_view.insert(peer);
     }
@@ -632,6 +636,9 @@ where
     fn handle_pending_neighbor_timer(&mut self, peer: PI, io: &mut impl IO<PI>) {
         if self.pending_neighbor_requests.remove(&peer) {
             self.passive_view.remove(&peer);
+            // Clear metadata and eviction markers to prevent memory leaks on neighbor handshake timeout
+            self.peer_data.remove(&peer);
+            self.alive_disconnect_peers.remove(&peer);
             self.refill_active_from_passive(&[], io);
         }
     }
@@ -671,6 +678,9 @@ where
                 if !matches!(reason, RemovalReason::ConnectionClosed) {
                     self.alive_disconnect_peers.insert(peer);
                 }
+            } else {
+                // Clear metadata from map for fully discarded peers to prevent persistent memory leak
+                self.peer_data.remove(&peer);
             }
             debug!(other = ?peer, "removed from active view, reason: {reason:?}");
             Some(peer)

--- a/src/proto/plumtree.rs
+++ b/src/proto/plumtree.rs
@@ -740,6 +740,30 @@ impl<PI: PeerIdentity> State<PI> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// Regression for n0-computer/iroh-gossip#146: a downed neighbor must be
+    /// dropped from `lazy_push_queue`, not just from the eager/lazy peer sets.
+    /// Without the prune the queued IHaves linger, leaking one entry per
+    /// rotated neighbor under churn.
+    #[test]
+    fn neighbor_down_prunes_lazy_push_queue() {
+        let mut state = State::new(1u32, Config::default(), 1024);
+        let peer = 2u32;
+        // Seed a queued lazy-push IHave for the peer.
+        state.lazy_push_queue.entry(peer).or_default().push(IHave {
+            id: MessageId::from_content(b"x"),
+            round: Round(1),
+        });
+        assert!(state.lazy_push_queue.contains_key(&peer));
+
+        state.on_neighbor_down(peer);
+
+        assert!(
+            !state.lazy_push_queue.contains_key(&peer),
+            "on_neighbor_down must prune the peer from lazy_push_queue"
+        );
+    }
+
     #[test]
     fn optimize_tree() {
         let mut io = VecDeque::new();

--- a/src/proto/plumtree.rs
+++ b/src/proto/plumtree.rs
@@ -676,6 +676,8 @@ impl<PI: PeerIdentity> State<PI> {
         });
         self.eager_push_peers.remove(&peer);
         self.lazy_push_peers.remove(&peer);
+        // Clear the lazy push queue to prevent lingering peer IDs from leaking memory when a neighbor goes down
+        self.lazy_push_queue.remove(&peer);
     }
 
     fn on_evict_cache_timer(&mut self, now: Instant, io: &mut impl IO<PI>) {

--- a/src/proto/state.rs
+++ b/src/proto/state.rs
@@ -283,6 +283,10 @@ impl<PI: PeerIdentity, R: Rng + SeedableRng> State<PI, R> {
                 if let topic::InEvent::UpdatePeerData(data) = &event {
                     self.me_data = data.clone();
                 }
+                if let topic::InEvent::PeerDisconnected(peer) = &event {
+                    // Prune the peer from the topics tracking index to prevent a persistent memory leak under node churn
+                    self.peer_topics.remove(peer);
+                }
                 for (topic, state) in self.states.iter_mut() {
                     let out = state.handle(event.clone(), now);
                     for event in out {

--- a/src/proto/state.rs
+++ b/src/proto/state.rs
@@ -383,3 +383,40 @@ fn track_in_event<PI: Serialize>(event: &InEvent<PI>, metrics: &Metrics) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use n0_future::time::Instant;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use super::*;
+
+    /// Regression for n0-computer/iroh-gossip#146: a network-level
+    /// `PeerDisconnected` must prune the peer from the top-level `peer_topics`
+    /// index. That index is otherwise never cleared on disconnect, so it leaks
+    /// one entry per rotated peer under churn (it's rebuilt from the next
+    /// message if the peer reconnects).
+    #[test]
+    fn peer_disconnected_prunes_peer_topics() {
+        let mut state: State<u32, StdRng> = State::new(
+            0,
+            PeerData::new(Vec::<u8>::new()),
+            Config::default(),
+            StdRng::seed_from_u64(1),
+        );
+        let peer = 7u32;
+        state.peer_topics.insert(peer, HashSet::default());
+        assert!(state.peer_topics.contains_key(&peer));
+
+        state
+            .handle(InEvent::PeerDisconnected(peer), Instant::now(), None)
+            .for_each(drop);
+
+        assert!(
+            !state.peer_topics.contains_key(&peer),
+            "PeerDisconnected must prune the peer from peer_topics"
+        );
+    }
+}


### PR DESCRIPTION
## Description

While running iroh-gossip as the mesh layer of a downstream project, we hit steadily growing
memory under sustained peer churn (peers continuously joining and leaving, each with a fresh
node id). Investigation found one dominant connection-task leak plus five smaller peer-state
eviction gaps. This PR fixes all of them; they're independent, so happy to split if you'd prefer.

First — thank you for iroh-gossip. Being able to lean on HyParview + Plumtree over iroh instead of
hand-rolling gossip and membership let us delete a large amount of networking code, and the actor
design made this leak tractable to trace.

### The dominant fix — `SendLoop` doesn't exit when its send channel closes (`src/net/util.rs`)

`SendLoop::run`'s select used:

```rust
Some(msg) = self.send_rx.recv() => self.write_message(&msg).await?,
```

When a peer is removed from the gossip peer map, its `send_tx` is dropped and `send_rx.recv()`
returns `None`. With the `Some(msg) = …` form, a `None` **silently disables that select branch**
(rather than yielding the `None`). The only other persistent arm, `_ = &mut closed`, then stays
pending forever because the connection is still open — so `SendLoop::run` never returns, `send_fut`
never resolves, and `connection_loop` is stuck. The `Connection` and its background
`ConnectionDriver` are never dropped: one stranded connection per removed/rotated peer.

Fix: match the full `Option` and break on `None`:

```rust
msg = self.send_rx.recv() => match msg {
    Some(msg) => self.write_message(&msg).await?,
    None => break, // all senders dropped: peer removed, tear the send side down
},
```

This pairs with changing `connection_loop` from `tokio::join!(send_fut, recv_fut)` to a
`tokio::select!` (a necessary prerequisite — with `join!`, even a returning `send_fut` would wait
forever on `recv_fut`'s `accept_uni()` because the peer is still alive), and removing the peer from
the actor's `peers` map on dial failure and on send-connection close so the descriptor is reclaimed.

### Additional eviction gaps noticed while investigating

These are smaller (byte-scale) and reasoned rather than independently soak-validated; each is a
spot where peer metadata outlived the peer:

- **`peer_topics` on `PeerDisconnected` (`proto/state.rs`)** — a network-level disconnect never
  removed the peer from this top-level index. Safe to remove here: the entry is rebuilt on the next
  message from the peer if it reconnects.
- **`peer_data` on active-view discard (`proto/hyparview.rs`)** — when a peer is removed from the
  active view and not retained as passive, its `peer_data` entry was left behind. Removed only on
  the not-kept branch, so peers that are kept as passive are untouched.
- **`peer_data` + `alive_disconnect_peers` on passive-view eviction (`proto/hyparview.rs`)** — when
  the passive view is full and a peer is evicted at random to make room, both its `peer_data` and
  `alive_disconnect_peers` entries were left behind.
- **`peer_data` + `alive_disconnect_peers` on pending-neighbor timeout (`proto/hyparview.rs`)** —
  same lingering state when a pending neighbor request times out.
- **`lazy_push_queue` on neighbor down (`proto/plumtree.rs`)** — when a neighbor goes down the peer
  is removed from the eager/lazy push peer sets, but its entry in the Plumtree `lazy_push_queue` was
  left behind.

## Breaking Changes

None. All changes are internal to the gossip actor and protocol state; no public API changes.

## Notes & open questions

- **Evidence (downstream, not reproducible here):** instrumenting spawned-vs-finished connection
  tasks under churn showed them climbing unbounded (e.g. spawned 174 / finished 52) while the
  HyParview active view stayed bounded (~15) — the smoking gun for the `SendLoop` hang. With the
  fix, finished tracks spawned and live connection tasks stay bounded at the active-peer count; a
  heap profile's QUIC `Connection` retention dropped accordingly. Numbers are from our soak, so I'd
  treat them as supporting context — a before/after on your CI churn setup is the authoritative check.
- **Tests:** the five eviction fixes are straightforward to assert. A focused regression test for
  the `SendLoop` hang needs a connected-endpoint harness (drop the peer's `send_tx`, assert `run()`
  returns rather than hanging) — happy to add one in the style you prefer if useful.
- Would you like the five eviction fixes split into a separate PR from the `SendLoop`/`select!` fix?

## Related

This was one of three churn-related memory-leak fixes found together while running the iroh stack
under sustained churn; the connection-leak picture spans the gossip send loop here and a noq
`Connecting` drop fix:
- n0-computer/iroh#4294 — `mapped_addrs` eviction on actor shutdown
- n0-computer/noq#682 — close the connection when a `Connecting` is dropped pre-handshake

## Checklist

- [x] Self-review
- [x] Documented the reasoning inline where the fix is non-obvious (the `None => break` comment)
- [ ] Tests — see note above; glad to add a harness-based regression test on request
- [x] No breaking changes


Resolves #145
