### PR TITLE
fix: close superseded connections and prune peer-state on churn

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -441,6 +441,9 @@ impl Actor {
                             self.handle_in_event(InEvent::PeerDisconnected(peer_id), Instant::now())
                                 .await;
                         }
+                        // Reclaim the peer descriptor on dial failure so it doesn't
+                        // linger in the tracking map (from n0-computer/iroh-gossip#146).
+                        self.peers.remove(&peer_id);
                     }
                     None => {
                         warn!(peer = %peer_id.fmt_short(), "dial disconnected");
@@ -583,6 +586,9 @@ impl Actor {
                 debug!("active send connection closed, mark peer as disconnected");
                 self.handle_in_event(InEvent::PeerDisconnected(peer_id), Instant::now())
                     .await;
+                // Drop the peer descriptor when its active connection closes so it
+                // doesn't leak in the tracking map (from n0-computer/iroh-gossip#146).
+                self.peers.remove(&peer_id);
             } else {
                 other_conns.retain(|x| *x != conn.stable_id());
                 debug!("remaining {} other connections", other_conns.len() + 1);

--- a/src/net.rs
+++ b/src/net.rs
@@ -894,9 +894,22 @@ async fn connection_loop(
     let send_fut = send_loop.run(queue).instrument(error_span!("send"));
     let recv_fut = recv_loop.run().instrument(error_span!("recv"));
 
-    let (send_res, recv_res) = tokio::join!(send_fut, recv_fut);
-    send_res?;
-    recv_res?;
+    // Exit as soon as *either* half finishes, rather than waiting for both.
+    // When this connection is superseded by a newer one to the same peer
+    // (`PeerState::accept_conn` drops its `send_tx`), the send loop ends but the
+    // recv loop would otherwise run forever — the peer keeps the connection
+    // alive via keep-alives, so it never idle-times-out and is never closed.
+    // That leaks the whole connection (its driver + transport state) once per
+    // churned connection. Finishing here lets the spawned task complete →
+    // `handle_connection_task_finished` closes the connection → it drains and is
+    // reclaimed. For the *active* connection the send loop never ends (its
+    // sender is held in `PeerState`), so this still exits only when the recv
+    // loop does (peer-initiated close) — unchanged. The dropped future is
+    // cancelled, which is fine: the connection is being torn down regardless.
+    tokio::select! {
+        send_res = send_fut => send_res?,
+        recv_res = recv_fut => recv_res?,
+    }
     Ok(())
 }
 
@@ -1531,6 +1544,69 @@ pub(crate) mod tests {
             .await
             .std_context("wait actor finish")?;
 
+        Ok(())
+    }
+
+    /// Regression test: a [`SendLoop`] must terminate once its send channel is
+    /// closed (all senders dropped), which is how a superseded or disconnected
+    /// connection is signalled — [`PeerState::accept_conn`] drops the old
+    /// connection's `send_tx`, and [`Actor::handle_in_event`] drops it on
+    /// `DisconnectPeer`.
+    ///
+    /// Previously the send loop's `select!` used `Some(msg) = recv()` plus an
+    /// `else => break`. That `else` was dead code: the biased `closed` branch
+    /// stayed enabled-and-pending, so the loop blocked on `closed` forever
+    /// instead of breaking when the channel closed. The connection (and its
+    /// `connection_loop`) then lived until the *peer* closed it — which under
+    /// keep-alive never happened — leaking one connection per churned link.
+    ///
+    /// [`SendLoop`]: util::SendLoop
+    #[tokio::test]
+    #[traced_test]
+    async fn send_loop_terminates_when_send_channel_closed() -> Result {
+        let rng = &mut rand::rngs::ChaCha12Rng::seed_from_u64(1);
+        let (relay_map, relay_url, _guard) =
+            iroh::test_utils::run_relay_server().await.unwrap();
+        let ep1 = create_endpoint(rng, relay_map.clone(), None).await?;
+        let ep2 = create_endpoint(rng, relay_map.clone(), None).await?;
+
+        // Let ep1 resolve ep2's address.
+        let memory_lookup = MemoryLookup::new();
+        memory_lookup.add_endpoint_info(EndpointAddr::new(ep2.id()).with_relay_url(relay_url));
+        ep1.address_lookup()?.add(memory_lookup);
+
+        let ep2_id = ep2.id();
+        // ep2 accepts the connection and holds it open (so the only thing that can
+        // make the send loop exit is the closed send channel, not the peer).
+        let accept_task = task::spawn(async move {
+            if let Some(incoming) = ep2.accept().await {
+                if let Ok(conn) = incoming.await {
+                    conn.closed().await;
+                }
+            }
+        });
+
+        let conn = ep1
+            .connect(ep2_id, GOSSIP_ALPN)
+            .await
+            .std_context("connect")?;
+
+        // A send channel whose only sender is immediately dropped models a
+        // just-superseded connection.
+        let (send_tx, send_rx) = mpsc::channel::<ProtoMessage>(1);
+        drop(send_tx);
+
+        // With the fix this returns promptly; with the bug it blocks on
+        // `conn.closed()` forever and the timeout fires.
+        let mut send_loop = util::SendLoop::new(conn, send_rx, 1024);
+        let res = timeout(Duration::from_secs(5), send_loop.run(vec![])).await;
+        assert!(
+            res.is_ok(),
+            "SendLoop must terminate when its send channel closes (superseded connection)"
+        );
+        res.expect("send loop returned").std_context("send loop run")?;
+
+        accept_task.abort();
         Ok(())
     }
 

--- a/src/net/util.rs
+++ b/src/net/util.rs
@@ -231,9 +231,21 @@ impl SendLoop {
             tokio::select! {
                 biased;
                 _ = &mut closed => break,
-                Some(msg) = self.send_rx.recv() => self.write_message(&msg).await?,
+                // Break when the send channel is closed (all senders dropped),
+                // i.e. this connection was superseded or the peer disconnected.
+                // A previous `Some(msg) = recv()` arm plus `else => break` never
+                // broke on channel closure: the `closed` branch above stays
+                // enabled-and-pending, so `else` (which only runs when *every*
+                // branch is disabled) never fired, and the send loop blocked on
+                // `closed` forever. That left the superseded connection's
+                // `connection_loop` running indefinitely — the connection (and its
+                // backing transport state) was never closed or reclaimed, leaking
+                // one connection per churned link under active-view churn.
+                msg = self.send_rx.recv() => match msg {
+                    Some(msg) => self.write_message(&msg).await?,
+                    None => break,
+                },
                 _ = self.finishing.join_next(), if !self.finishing.is_empty() => {}
-                else => break,
             }
         }
 

--- a/src/proto/hyparview.rs
+++ b/src/proto/hyparview.rs
@@ -580,7 +580,13 @@ where
             return;
         }
         if self.passive_is_full() {
-            self.passive_view.remove_random(&mut self.rng);
+            if let Some(evicted_peer) = self.passive_view.remove_random(&mut self.rng) {
+                // Prune the evicted peer's metadata + eviction marker so they
+                // don't accumulate as stale per-peer state under churn
+                // (from n0-computer/iroh-gossip#146).
+                self.peer_data.remove(&evicted_peer);
+                self.alive_disconnect_peers.remove(&evicted_peer);
+            }
         }
         self.passive_view.insert(peer);
     }
@@ -632,6 +638,10 @@ where
     fn handle_pending_neighbor_timer(&mut self, peer: PI, io: &mut impl IO<PI>) {
         if self.pending_neighbor_requests.remove(&peer) {
             self.passive_view.remove(&peer);
+            // Prune metadata + eviction marker on neighbor-handshake timeout so
+            // they don't outlive the peer (from n0-computer/iroh-gossip#146).
+            self.peer_data.remove(&peer);
+            self.alive_disconnect_peers.remove(&peer);
             self.refill_active_from_passive(&[], io);
         }
     }
@@ -671,6 +681,10 @@ where
                 if !matches!(reason, RemovalReason::ConnectionClosed) {
                     self.alive_disconnect_peers.insert(peer);
                 }
+            } else {
+                // Fully discarded (not kept as passive): drop its metadata so it
+                // doesn't linger (from n0-computer/iroh-gossip#146).
+                self.peer_data.remove(&peer);
             }
             debug!(other = ?peer, "removed from active view, reason: {reason:?}");
             Some(peer)
@@ -761,4 +775,82 @@ enum RemovalReason {
     DisconnectReceived { is_alive: bool },
     /// A peer is removed after random selection to make room for a newly joined peer.
     Random,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use super::*;
+    use crate::proto::topic::OutEvent as TopicOut;
+
+    fn state() -> State<u32, StdRng> {
+        State::new(0u32, None, Config::default(), StdRng::seed_from_u64(1))
+    }
+
+    // Regressions for n0-computer/iroh-gossip#146: per-peer metadata
+    // (`peer_data`, `alive_disconnect_peers`) must be pruned when a peer leaves,
+    // rather than accumulating as stale state under churn. One test per eviction
+    // path — revert that path's prune and only its test goes red.
+
+    #[test]
+    fn passive_view_eviction_prunes_metadata() {
+        let mut state = state();
+        state.config.passive_view_capacity = 1;
+        let mut io = VecDeque::<TopicOut<u32>>::new();
+        state.add_passive(10, None, &mut io); // passive view now {10}
+        state.peer_data.insert(10, PeerData::new(vec![1]));
+        state.alive_disconnect_peers.insert(10);
+        // Adding another peer evicts the (single) passive peer at random = 10.
+        state.add_passive(11, None, &mut io);
+        assert!(
+            !state.peer_data.contains_key(&10),
+            "passive-view eviction must prune peer_data"
+        );
+        assert!(
+            !state.alive_disconnect_peers.contains(&10),
+            "passive-view eviction must prune alive_disconnect_peers"
+        );
+    }
+
+    #[test]
+    fn pending_neighbor_timeout_prunes_metadata() {
+        let mut state = state();
+        let mut io = VecDeque::<TopicOut<u32>>::new();
+        let peer = 20;
+        state.pending_neighbor_requests.insert(peer);
+        state.passive_view.insert(peer);
+        state.peer_data.insert(peer, PeerData::new(vec![2]));
+        state.alive_disconnect_peers.insert(peer);
+        state.handle_pending_neighbor_timer(peer, &mut io);
+        assert!(
+            !state.peer_data.contains_key(&peer),
+            "pending-neighbor timeout must prune peer_data"
+        );
+        assert!(
+            !state.alive_disconnect_peers.contains(&peer),
+            "pending-neighbor timeout must prune alive_disconnect_peers"
+        );
+    }
+
+    #[test]
+    fn active_view_discard_prunes_metadata() {
+        let mut state = state();
+        let mut io = VecDeque::<TopicOut<u32>>::new();
+        let peer = 30;
+        state.active_view.insert(peer);
+        state.peer_data.insert(peer, PeerData::new(vec![3]));
+        // is_alive=false => not kept as passive => peer_data must be dropped.
+        state.remove_active(
+            &peer,
+            RemovalReason::DisconnectReceived { is_alive: false },
+            &mut io,
+        );
+        assert!(
+            !state.peer_data.contains_key(&peer),
+            "active-view discard (not kept) must prune peer_data"
+        );
+    }
 }

--- a/src/proto/plumtree.rs
+++ b/src/proto/plumtree.rs
@@ -676,6 +676,9 @@ impl<PI: PeerIdentity> State<PI> {
         });
         self.eager_push_peers.remove(&peer);
         self.lazy_push_peers.remove(&peer);
+        // Also drop any queued lazy-push IHaves for the downed peer so its entry
+        // doesn't linger in the queue map (from n0-computer/iroh-gossip#146).
+        self.lazy_push_queue.remove(&peer);
     }
 
     fn on_evict_cache_timer(&mut self, now: Instant, io: &mut impl IO<PI>) {
@@ -738,6 +741,30 @@ impl<PI: PeerIdentity> State<PI> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// Regression for n0-computer/iroh-gossip#146: a downed neighbor must be
+    /// dropped from `lazy_push_queue`, not just from the eager/lazy peer sets.
+    /// Without the prune the queued IHaves linger, leaking one entry per
+    /// rotated neighbor under churn.
+    #[test]
+    fn neighbor_down_prunes_lazy_push_queue() {
+        let mut state = State::new(1u32, Config::default(), 1024);
+        let peer = 2u32;
+        // Seed a queued lazy-push IHave for the peer.
+        state.lazy_push_queue.entry(peer).or_default().push(IHave {
+            id: MessageId::from_content(b"x"),
+            round: Round(1),
+        });
+        assert!(state.lazy_push_queue.contains_key(&peer));
+
+        state.on_neighbor_down(peer);
+
+        assert!(
+            !state.lazy_push_queue.contains_key(&peer),
+            "on_neighbor_down must prune the peer from lazy_push_queue"
+        );
+    }
+
     #[test]
     fn optimize_tree() {
         let mut io = VecDeque::new();

--- a/src/proto/state.rs
+++ b/src/proto/state.rs
@@ -283,6 +283,12 @@ impl<PI: PeerIdentity, R: Rng + SeedableRng> State<PI, R> {
                 if let topic::InEvent::UpdatePeerData(data) = &event {
                     self.me_data = data.clone();
                 }
+                if let topic::InEvent::PeerDisconnected(peer) = &event {
+                    // Prune the peer from the top-level topics index so it doesn't
+                    // linger under churn; it's rebuilt from the next message if the
+                    // peer reconnects (from n0-computer/iroh-gossip#146).
+                    self.peer_topics.remove(peer);
+                }
                 for (topic, state) in self.states.iter_mut() {
                     let out = state.handle(event.clone(), now);
                     for event in out {
@@ -377,5 +383,42 @@ fn track_in_event<PI: Serialize>(event: &InEvent<PI>, metrics: &Metrics) {
                     .inc_by(message.size().unwrap_or(0) as u64);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use n0_future::time::Instant;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use super::*;
+
+    /// Regression for n0-computer/iroh-gossip#146: a network-level
+    /// `PeerDisconnected` must prune the peer from the top-level `peer_topics`
+    /// index. That index is otherwise never cleared on disconnect, so it leaks
+    /// one entry per rotated peer under churn (it's rebuilt from the next
+    /// message if the peer reconnects).
+    #[test]
+    fn peer_disconnected_prunes_peer_topics() {
+        let mut state: State<u32, StdRng> = State::new(
+            0,
+            PeerData::new(Vec::<u8>::new()),
+            Config::default(),
+            StdRng::seed_from_u64(1),
+        );
+        let peer = 7u32;
+        state.peer_topics.insert(peer, HashSet::default());
+        assert!(state.peer_topics.contains_key(&peer));
+
+        state
+            .handle(InEvent::PeerDisconnected(peer), Instant::now(), None)
+            .for_each(drop);
+
+        assert!(
+            !state.peer_topics.contains_key(&peer),
+            "PeerDisconnected must prune the peer from peer_topics"
+        );
     }
 }


### PR DESCRIPTION
First, thank you for the work on the iroh-gossip project 🙇‍♂️.

This PR corrects the largest part of a memory leak. I found the leak on a local mesh and on a distributed mesh. Both run iroh-gossip with continuous peer churn.

> [!NOTE]
> #146 from @drlukeangel found and corrected the same two core bugs, and came first. The two bugs are the `join!` in `connection_loop` and the missing `None => break` in `SendLoop`. This PR has the same two fixes. It also has the seven peer-state prunes from #146, with credit in the section below, and the regression tests that #146 does not have yet. Use the form that is best for you. You can close this PR for #146, or move the tests across.

Related: #146, #145, https://github.com/n0-computer/noq/pull/683

## Summary

With continuous connection churn, a gossip node leaks approximately one full connection for each churned link. Active-view maintenance in HyParView in a large swarm is one example. The RSS increases without a limit, and the CPU load increases.

The leaked connections stay open and idle. Keep-alives hold them open, and nothing closes them. This PR corrects two related bugs. These two bugs prevent the end of the `connection_loop` of a *superseded* connection.

## Background

When a peer dials again, `PeerState::accept_conn` supersedes the old connection. It moves the old connection into `other_conns`. It puts the new send channel in place. It drops the `send_tx` of the old connection.

The comment in `accept_conn` gives the intent. The drop of `send_tx` starts this chain:

1. The old send loop ends.
2. The `connection_loop` task ends.
3. `handle_connection_task_finished` closes the connection.
4. The connection drains, and the code reclaims it.

The chain never completes, because of two bugs.

### Bug 1 — `connection_loop` waits for *both* halves (`net.rs`)

```rust
let (send_res, recv_res) = tokio::join!(send_fut, recv_fut);
```

`join!` returns only after **both** loops end. After a supersede, the send loop ends. The recv loop continues until the *peer* closes the connection. The peer does not close it, because keep-alives prevent the idle timeout. Thus the task does not end, and the code does not reach the close path.

### Bug 2 — `SendLoop::run` never breaks when its channel closes (`net/util.rs`)

```rust
loop {
    tokio::select! {
        biased;
        _ = &mut closed => break,
        Some(msg) = self.send_rx.recv() => self.write_message(&msg).await?,
        _ = self.finishing.join_next(), if !self.finishing.is_empty() => {}
        else => break,
    }
}
```

When the channel closes, the `else => break` must stop the loop. But it is **dead code**. When `send_rx` closes, `Some(msg) = recv()` gives `None`, and `select!` disables that branch. The biased `_ = &mut closed` branch stays *enabled and pending*. Thus `select!` continues to wait for it.

The `else` branch runs only when *all* branches are disabled, so it never runs. The send loop waits on `closed` for ever. With the fix for Bug 1 alone, `send_fut` still does not complete after a supersede.

The result: the loop of a superseded connection ends only when the *peer* closes the connection on the recv side. Keep-alives prevent this. Thus the loops accumulate without a limit.

## Fix

- **Bug 1:** Use `tokio::select!` in place of `join!`. The task ends when one of the two halves ends. The end of a superseded send loop now ends the task. Then the connection closes, drains, and the code reclaims it. The active connection does not change. Its `send_tx` stays in `PeerState`, thus its send loop does not end. It ends only after the peer closes the connection.
- **Bug 2:** Match `recv()` directly, and break on `None`. When its channel closes, the send loop stops.

Both fixes are necessary. `select!` alone is not sufficient, because `send_fut` does not complete without the `SendLoop` fix.

## Peer-state eviction prunes (adopted from #146)

The connection leak is not the only leak. Several maps that hold data for each peer were never cleared when a peer left. When churn rotates the node ids, each map leaks one entry for each peer. The quantity is small, but it has no limit. The seven prunes below are the work of @drlukeangel, from #146. This PR includes them to make the fix set complete.

- **`net.rs`** — Remove the peer from the `peers` map after a dial failure, and after the close of the active send connection.
- **`proto/hyparview.rs`** — Remove `peer_data` and `alive_disconnect_peers` in three places. These places are passive-view eviction, a timeout of a pending neighbor request, and active-view discard (the branch that does not keep the peer as passive).
- **`proto/plumtree.rs`** — Remove the peer from `lazy_push_queue` when the neighbor goes down.
- **`proto/state.rs`** — Remove the peer from `peer_topics` on `PeerDisconnected`.

## Tests

- **`send_loop_terminates_when_send_channel_closed`** (`net.rs`) — The test opens a real connection. It drops the only sender of the send channel, which models a supersede. Then it makes sure that `SendLoop::run` returns before a timeout. The test times out with the unfixed code. It passes with the fix.
- **Five regression tests in the proto modules**, for the eviction prunes: hyparview (passive-evict, pending-timeout, active-discard), plumtree (`lazy_push_queue`), and state (`peer_topics`). Each test fills the related map, causes the eviction, and makes sure that the entry is gone. Each test fails when its prune line is not there. #146 says that these tests are easy to write, but keeps them for later. They are here.

## Impact (measured downstream)

The table shows the dhat heap profile of a node with churn, before and after the connection-leak fix. The node has an active view with a limit of 5, 9 peers, and a loopback network.

| | before | after |
|---|---|---|
| heap retained at exit | 47.8 MB | **4.6 MB** |
| retained `Connection::new` blocks | 341 | 140 (steady state) |
| RSS over the run | climbing | **flat** |
| live `connection_loop`s | 261 and climbing | **~1–8, flat** |

The accumulation of connection loops also increases the CPU load. This increase stops with the fix.

## Notes

The behavior on the healthy path does not change. Only the superseded path and the disconnected path change. Before, the connection stayed open until the peer or the idle timeout closed it, and keep-alives prevented this. Now, the connection closes immediately.

The code can drop some messages that are in flight on a connection that was just superseded. This is acceptable for gossip, because gossip delivers each message more than one time and has anti-entropy.
